### PR TITLE
Allow container to write into runtime directories

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -102,5 +102,5 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/code/docker/launch_automation_reporter.sh"]
 EXPOSE 8053
 
-RUN chmod 0777 /var/log/nginx /var/lib/nginx/tmp
+RUN chmod 0777 /var/log/nginx /var/lib/nginx /var/lib/nginx/tmp /var/lib/awx/
 USER awx


### PR DESCRIPTION
Container will be started with 'podman .. --userns keep-id". The user id from container host needs to have write permission for those directories.

Without this code worked only when user with id 1000 was installing. A few users installed with different uid, and web container did not start, because nginx was not allowed to write to its tmp directory.