### PR TITLE
Fix sync data when launched by is missing

### DIFF
--- a/src/backend/apps/clusters/parser.py
+++ b/src/backend/apps/clusters/parser.py
@@ -70,7 +70,7 @@ class DataParser:
     @property
     def launched_by(self) -> AAPUser | None:
         external_launched_by = self.data.launched_by
-        if external_launched_by:
+        if external_launched_by and external_launched_by.id:
             return AAPUser.create_or_update(
                 cluster=self.cluster,
                 external_id=external_launched_by.id,

--- a/src/backend/apps/clusters/schemas.py
+++ b/src/backend/apps/clusters/schemas.py
@@ -89,9 +89,9 @@ class SummaryFields(FrozenModel):
 
 
 class LaunchedBy(FrozenModel):
-    id: int
-    name: str
-    type: str
+    id: int | None = None
+    name: str | None = None
+    type: str | None = None
 
 
 class HostSummarySummaryFieldsSchema(FrozenModel):


### PR DESCRIPTION
This pull request introduces improvements to how user launch information is handled in cluster parsing and schema validation. The main focus is on making the handling of the `LaunchedBy` user information more robust by supporting cases where some fields may be missing.

https://issues.redhat.com/browse/AAP-51558