### PR TITLE
Make initial sync window configurable

### DIFF
--- a/src/backend/django_config/settings.py
+++ b/src/backend/django_config/settings.py
@@ -342,6 +342,11 @@ AAP_AUTH_PROVIDER = {
     'client_secret': '<client secret>',
 }
 
+# Initial sync timedelta in days
+INITIAL_SYNC_DAYS = 1
+
+# Initial sync date (overrides INITIAL_SYNC_DAYS)
+INITIAL_SYNC_SINCE = '2025-08-08'
 
 ### Local settings
 local_config_file = os.path.join(BASE_DIR, "django_config", "local_settings.py")


### PR DESCRIPTION
This pull request updates the initial sync logic for cluster data, making it configurable via Django settings and adding comprehensive tests to ensure correct behavior. The main improvement is allowing the initial sync date or period to be set through settings, which increases flexibility and control for deployments.

closes: #72 