### PR TITLE
Build container image and bundled installer only for tags and main branch

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,10 @@ name: Build
 
 on:
   push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - main
 
 jobs:
   build-image:
@@ -54,12 +58,10 @@ jobs:
           registry: quay.io/aap
           username: ${{ vars.REGISTRY_QUAY_IO_USERNAME }}
           password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/gha-bundle'
 
   build-bundle:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/gha-bundle'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/setup/README.md
+++ b/setup/README.md
@@ -40,7 +40,14 @@ Open http://HOST_IP:8083/.
 
 ## Bundled installer
 
-### Build bundled installer
+### Build bundled installer - using GitHub actions
+
+The bundled installer is build by GitHub action in two steps.
+The first step builds a container image and pushes it to a container image registry (quay.io).
+The second steps uses the container image and produces a bundled installer (a tarball).
+Bundled installer is available for download as GHA artifact, from corresponding GHA job.
+
+### Build bundled installer - manually
 
 Bundled installer is build on build host, and deployed on other VMs.
 Bundled installer contains also needed container images.


### PR DESCRIPTION
PR will build image and bundled installer only for tags and main branch.
Documentation is extended to note that GHA is used for building.

fixes #96 