### PR TITLE
Change default values and remove unused parameter

### DIFF
--- a/src/backend/api/v1/cost/views.py
+++ b/src/backend/api/v1/cost/views.py
@@ -32,7 +32,7 @@ class CostView(AdminOnlyViewSet, mixins.ListModelMixin, mixins.CreateModelMixin,
             instance.value = value
             instance.save()
 
-        costs = Costs.get(from_db=True)
+        costs = Costs.get()
         response_data = {
             "manual_cost_automation": costs[CostsChoices.MANUAL],
             "automated_process_cost": costs[CostsChoices.AUTOMATED]

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -591,7 +591,7 @@ class Costs(CreatUpdateModel):
         return f'{self.type}: {self.value}'
 
     @classmethod
-    def get(cls, from_db: bool = False) -> dict[str, decimal.Decimal]:
+    def get(cls) -> dict[str, decimal.Decimal]:
 
         """
         This function retrieves the current cost entries (manual and automated) from the database.

--- a/src/backend/django_config/settings.py
+++ b/src/backend/django_config/settings.py
@@ -244,16 +244,16 @@ CSRF_HEADER_NAME = "HTTP_X_XSRF_TOKEN"
 # Defaults
 
 # Default Time taken to manually execute automation (min)
-DEFAULT_TIME_TAKEN_TO_MANUALLY_EXECUTE_MINUTES = 60
+DEFAULT_TIME_TAKEN_TO_MANUALLY_EXECUTE_MINUTES = 1
 
 # Default Time taken to manually create automation (min)
 DEFAULT_TIME_TAKEN_TO_CREATE_AUTOMATION_MINUTES = 60
 
 #Default average cost of an employee per minute
-DEFAULT_MANUAL_COST_AUTOMATION = 50
+DEFAULT_MANUAL_COST_AUTOMATION = 1
 
 #Deafult cost per minute of AAP
-DEFAULT_AUTOMATED_PROCESS_COST = 20
+DEFAULT_AUTOMATED_PROCESS_COST = 1
 
 
 # feature flags


### PR DESCRIPTION
**Cost retrieval logic update:**

* Removed the `from_db` parameter from the `Costs.get` method and updated its usage in `views.py` for consistency and simplification. [[1]](diffhunk://#diff-bc013964f66a1edcf87f90c49d7b49f9e9029318ee9ce08fe416dbb5c2d50a78L594-R594) [[2]](diffhunk://#diff-f079706b71a80101b83d7262fa77844d35afd863a282b304ff05d27588bae51cL35-R35)

**Default value adjustments:**

* Decreased `DEFAULT_TIME_TAKEN_TO_MANUALLY_EXECUTE_MINUTES` from 60 to 1 minute in `settings.py`.
* Lowered `DEFAULT_MANUAL_COST_AUTOMATION` from 50 to 1  `settings.py`.
* Lowered `DEFAULT_AUTOMATED_PROCESS_COST` from 20 to 1 in `settings.py`.