### PR TITLE
Create dispatcherd socket in private directory

### DIFF
--- a/src/backend/django_config/settings.py
+++ b/src/backend/django_config/settings.py
@@ -272,7 +272,7 @@ IS_K8S = False
 
 CLUSTER_HOST_ID = socket.gethostname()
 
-DISPATCHERD_DEBUGGING_SOCKFILE = "/tmp/demo_dispatcher.sock"
+DISPATCHERD_DEBUGGING_SOCKFILE = f"/run/user/{os.getuid()}/automation-dashboard-dispatcher.sock"
 
 # The number of processes spawned by the callback receiver to process job
 # events into the database


### PR DESCRIPTION
Create socket for dispatcherd in `/run/user/UID/`. This path is secure by default, OS takes care of it. No configuration, documentation or runtime change is needed on our side.

Fixes #74
