### PR TITLE
Fix AAP authentication example

### DIFF
--- a/setup/inventory.example
+++ b/setup/inventory.example
@@ -7,14 +7,16 @@ aap24_dashboard.novalocal ansible_connection=local
 aap_auth_provider_name=AnsibleAutomationPlatform
 # aap_auth_provider_protocol - http or https
 aap_auth_provider_protocol=https
-# aap_auth_provider_url - AAP IP or DNS name
-aap_auth_provider_url=my-aap.example.com
+# aap_auth_provider_url - AAP IP or DNS name, with optional port
+#   AAP 2.4 (controller API): my-aap.example.com:8443/api
+#   AAP 2.5 (gateway API): my-aap.example.com
+aap_auth_provider_url=my-aap.example.com:8443/api
+# aap_auth_provider_user_data_endpoint depends on AAP version:
+#   AAP 2.4 (controller API): /v2/me/
+#   AAP 2.5 (gateway API): /api/gateway/v1/me/
+aap_auth_provider_user_data_endpoint=/v2/me/
 # aap_auth_provider_check_ssl - enforce TLS check or not.
 aap_auth_provider_check_ssl=true
-# aap_auth_provider_user_data_endpoint depends on AAP version:
-#   AAP 2.4 (controller API): /api/v2/me/
-#   AAP 2.5 (gateway API): /api/gateway/v1/me/
-aap_auth_provider_user_data_endpoint=/api/v2/me/
 # aap_auth_provider_client_id and aap_auth_provider_client_secret -
 # they are obtained from AAP when OAuth2 application is created in AAP.
 aap_auth_provider_client_id=TODO


### PR DESCRIPTION
Fixes #119

@abwalczyk Thank you for reporting issue, I forgot to create PR. Can you confirm for AAP 2.4 you also needed to have `aap_auth_provider_url=my-aap.example.com:8443/api`?