### PR TITLE
Simplify inventory configuration

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
@@ -107,6 +107,20 @@
       - automation-dashboard-task.service
       - automation-dashboard-web.service
 
+- name: Set AAP version dependent facts
+  ansible.builtin.set_fact:
+    __aap_auth_provider_url: "{{ map_to_aap_url[aap_auth_provider_aap_version] }}"
+    __aap_auth_provider_user_data_endpoint: "{{ map_to_aap_user_data_endpoint[aap_auth_provider_aap_version] }}"
+  vars:
+    map_to_aap_url:
+      2.4: "{{ aap_auth_provider_host }}/api"
+      2.5: "{{ aap_auth_provider_host }}"
+      2.6: "{{ aap_auth_provider_host }}"
+    map_to_aap_user_data_endpoint:
+      2.4: "/v2/me/"
+      2.5: "/api/gateway/v1/me/"
+      2.6: "/api/gateway/v1/me/"
+
 # - name: Add rsyslog to systemd services list
 #   ansible.builtin.set_fact:
 #     __services: '{{ __services | union(["automation-dashboard-rsyslog.service"]) }}'

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/django_dashboard_conf.py.j2
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/django_dashboard_conf.py.j2
@@ -19,8 +19,8 @@ JWT_REFRESH_TOKEN_LIFETIME_SECONDS = 7200
 AAP_AUTH_PROVIDER = {
     "name": "{{ aap_auth_provider_name }}",
     "protocol": "{{ aap_auth_provider_protocol }}",
-    "url": "{{ aap_auth_provider_url }}",
-    "user_data_endpoint": "{{ aap_auth_provider_user_data_endpoint }}",
+    "url": "{{ __aap_auth_provider_url }}",
+    "user_data_endpoint": "{{ __aap_auth_provider_user_data_endpoint }}",
     "check_ssl": "{{ aap_auth_provider_check_ssl }}",
     "client_id": "{{ aap_auth_provider_client_id }}",
     "client_secret": "{{ aap_auth_provider_client_secret }}",

--- a/setup/inventory.example
+++ b/setup/inventory.example
@@ -7,14 +7,10 @@ host.example.com ansible_connection=local
 aap_auth_provider_name=Ansible Automation Platform
 # aap_auth_provider_protocol - http or https
 aap_auth_provider_protocol=https
-# aap_auth_provider_url - AAP IP or DNS name, with optional port
-#   AAP 2.4 (controller API): my-aap.example.com/api
-#   AAP 2.5 (gateway API): my-aap.example.com
-aap_auth_provider_url=my-aap.example.com/api
-# aap_auth_provider_user_data_endpoint depends on AAP version:
-#   AAP 2.4 (controller API): /v2/me/
-#   AAP 2.5 (gateway API): /api/gateway/v1/me/
-aap_auth_provider_user_data_endpoint=/v2/me/
+# AAP version - 2.4, 2.5 or 2.6
+# aap_auth_provider_aap_version=2.5
+# aap_auth_provider_host - AAP IP or DNS name, with optional port
+aap_auth_provider_host=my-aap.example.com
 # aap_auth_provider_check_ssl - enforce TLS check or not.
 aap_auth_provider_check_ssl=true
 # aap_auth_provider_client_id and aap_auth_provider_client_secret -


### PR DESCRIPTION
After PR is merged, user need to tell us (write into inventory file) only AAP version (2.4 or 2.5 etc).
User does not need anymore to read text about how to compute some partial URLs based on AAP version.

Fixes #133