### PR TITLE
add comprehensive instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ AAP_AUTH_PROVIDER = {
     # For AAP v2.4
     "url": "aap24.example.com:8443/api",
     "user_data_endpoint": "/v2/me/",
-    # For AAP v2.5
-    # "url": "aap25.example.com",  # Change to your AAP VM IP for AAP v2.5
-    # "user_data_endpoint": "/api/v2/me/",  # Change to /api/gateway/v1/me/ for AAP v2.5
+    # For AAP v2.5, v2.6
+    # "url": "aap25.example.com",
+    # "user_data_endpoint": "/api/gateway/v1/me/",
     #
     "check_ssl": False,
     "client_id": "TODO",  # Your OAuth client ID

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Automation Dashboard uses a distributed task processing architecture:
 ### Task Processing
 
 The application uses `dispatcherd` (replacing the previous `dramatiq` implementation) to handle:
+
 - Periodic synchronization of job data from AAP clusters
 - Background parsing and processing of job metrics
 - Scheduled task execution based on defined schedules
@@ -21,8 +22,8 @@ The application uses `dispatcherd` (replacing the previous `dramatiq` implementa
 ### Running locally
 
 The instructions assume commands will be executed on developers laptop.
-The python backend will be accessible on http://localhost:8000.
-The website frontend will be accessible on http://localhost:9000.
+The python backend will be accessible on <http://localhost:8000>.
+The website frontend will be accessible on <http://localhost:9000>.
 
 If python backend or website frontend runs on a different URL, instructions need to be adjusted.
 
@@ -34,9 +35,24 @@ The AAP OAuth2 application requires a redirect URL.
 
 The redirect URL for the AAP OAuth2 application needs to point to URL where you Automation Dashboard frontend is accessible.
 In this development setup we run frontend on localhost, on port 9000.
-Thus the redirect URL is http://localhost:9000/auth-callback.
+Thus the redirect URL is <http://localhost:9000/auth-callback>.
 
-#### Backend
+## Service Dependencies Overview
+
+The Automation Dashboard requires multiple services to run properly. Here's the recommended startup order:
+
+1. **Database (Docker)** - Must be running first
+2. **Django Backend** - Required for all API functionality and admin interface
+3. **Task Dispatcher** - Required for background sync tasks to be processed
+4. **Frontend** - Requires Django backend to be running
+
+**Important Notes:**
+
+- The **dispatcher must be running** for sync tasks to actually complete
+- The **Django backend must be running** for the frontend to work properly
+- Sync tasks created by `syncdata` commands will queue but won't process until the dispatcher is running
+
+## Backend
 
 ```bash
 python3.12 -m venv .venv
@@ -52,40 +68,137 @@ You might need to install required development libraries
 sudo dnf install python3.12-devel libpq-devel
 ```
 
-Create `local_settings.py` file.
-Review file. The content needs to be adjusted.
-In particular, the `AAP_AUTH_PROVIDER` variable needs to be populated.
+### Common Terminal Setup
+
+Throughout this guide, you'll need to prepare your terminal environment. Here's the standard pattern:
 
 ```bash
-cp -i src/backend/django_config/local_settings.example.py src/backend/django_config/local_settings.py
-nano src/backend/django_config/local_settings.py
+# Navigate to project directory
+cd /path/to/automation-reports
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Load environment variables
+source .env
+
+# Navigate to backend and set Python path
+cd src/backend
+export PYTHONPATH=$PWD/..
 ```
 
-#### Migrations and superuser
+**Note:** The sections below will reference "prepare your terminal" to mean running these commands.
+
+### Start Docker Database
+
+First, start the PostgreSQL database in Docker:
 
 ```bash
 cp -i .env.example .env
 source .env
 (cd compose; docker compose --project-directory .. -f compose.yml up --build db)
+```
 
-cd src/backend
-export PYTHONPATH=$PWD/.. # pip install -e .
+### Migrations and superuser
 
+Open a **new terminal**, prepare your terminal (see Common Terminal Setup above), and run:
+
+```bash
 python manage.py migrate
 python manage.py createsuperuser
 ```
 
-#### Set up instances
+### Set up AAP Clusters Configuration
 
-File `clusters.yaml` needs to contain the AAP access token.
+We need to create OAuth2 application and access token for integration with AAP.
+Follow [setup/README.md](setup/README.md#sso-authentication), section "SSO authentication".
+
+Create and configure the `clusters.yaml` file with your AAP cluster details:
 
 ```bash
 cp -i clusters.example.yaml clusters.yaml
 nano clusters.yaml
-python manage.py setclusters <path to yaml file>
 ```
 
-### Run
+**Edit the following variables in `clusters.yaml`:**
+
+- `address`: Change to your AAP VM IP address (e.g., `10.44.17.179`)
+- `port`: Change from `8443` to `443` if needed for your AAP setup
+- `access_token`: Replace `sampleToken` with your actual AAP access token
+- Remove any unused cluster instances from the file
+
+**About sync schedules:** The `sync_schedules` section in `clusters.yaml` automatically creates background sync tasks when loaded. Each schedule defines:
+
+- `name`: A descriptive name for the sync task
+- `rrule`: A recurrence rule (RFC 5545 format) that defines when syncing occurs
+- `enabled`: Whether this sync schedule is active
+
+Example configuration:
+
+```yaml
+---
+clusters:
+  - protocol: https
+    address: 10.44.17.179  # Your AAP VM IP
+    port: 8443             # change to 443
+    access_token: sampleToken # Actual access token
+    verify_ssl: false
+    sync_schedules:
+      - name: Every 5 minutes sync
+        rrule: DTSTART;TZID=Europe/Ljubljana:20250630T070000 FREQ=MINUTELY;INTERVAL=5
+        enabled: true
+      # You can add multiple sync schedules:
+      # - name: Hourly sync
+      #   rrule: DTSTART;TZID=Europe/Ljubljana:20250630T070000 FREQ=HOURLY;INTERVAL=1
+      #   enabled: false
+```
+
+Then load the cluster configuration (prepare your terminal first):
+
+```bash
+python manage.py setclusters clusters.yaml
+```
+
+### Setup SSO login with AAP
+
+Configure OAuth2 authentication by editing the `local_settings.py` file:
+
+```bash
+cd src/backend/django_config/
+cp -i local_settings.example.py local_settings.py
+nano local_settings.py
+```
+
+**Edit the following variables in `local_settings.py`:**
+
+- `url`: Change from `aap24.example.com` to your AAP VM IP
+- `user_data_endpoint`: Change from `/api/v2/me/` to `/api/gateway/v1/me/` for AAP v2.5
+- `client_id`: Replace `"TODO"` with your OAuth application client ID
+- `client_secret`: Replace `"TODO"` with your OAuth application client secret
+
+Example configuration:
+
+```python
+AAP_AUTH_PROVIDER = {
+    "name": "AnsibleAutomationPlatform",
+    "protocol": "https",
+    #
+    # For AAP v2.4
+    "url": "aap24.example.com:8443/api",
+    "user_data_endpoint": "/v2/me/",
+    # For AAP v2.5
+    # "url": "aap25.example.com",  # Change to your AAP VM IP for AAP v2.5
+    # "user_data_endpoint": "/api/v2/me/",  # Change to /api/gateway/v1/me/ for AAP v2.5
+    #
+    "check_ssl": False,
+    "client_id": "TODO",  # Your OAuth client ID
+    "client_secret": "TODO",  # Your OAuth client secret
+}
+```
+
+### Run Development Server
+
+Open a **new terminal**, prepare your terminal, and start the Django development server:
 
 ```bash
 python manage.py runserver
@@ -93,7 +206,9 @@ python manage.py runserver
 
 ### Sync AAP data
 
-The sync process now creates background tasks that are processed by the dispatcher:
+The sync process now creates background tasks that are processed by the dispatcher.
+
+Open a **new terminal**, prepare your terminal, and run sync commands:
 
 ```bash
 # Create a sync task for a specific date range
@@ -105,7 +220,17 @@ python manage.py syncdata
 
 ### Run the Task Dispatcher
 
-The dispatcher processes all background tasks including data syncs and parsing:
+The dispatcher processes all background tasks including data syncs and parsing.
+
+Automation Dashboard administrator is required to setup a scheduled task.
+Open <https://HOST:8447/admin/scheduler/syncschedule/> and click "Add sync schedule":
+
+- name: `5 minutes`
+- enabled: true
+- rrule: `DTSTART;TZID=Europe/Ljubljana:20250630T070000 FREQ=MINUTELY;INTERVAL=5`
+- cluster: select your cluster
+
+Open a **new terminal**, prepare your terminal, and run the dispatcher:
 
 ```bash
 # Start the dispatcher service
@@ -121,22 +246,31 @@ python manage.py run_dispatcher --running
 python manage.py run_dispatcher --cancel <task_uuid>
 ```
 
-**Note**: The dispatcher must be running for sync tasks to be processed. In production, this should be run as a separate service.
+**Important**:
+
+- The dispatcher must be running for sync tasks to be processed
+- Any sync tasks created by `syncdata` commands will queue but won't execute until the dispatcher is running
+- In production, this should be run as a separate service
+- The Django backend should be running before starting the dispatcher
 
 ### Tests
 
-```bash
-# source .env
+Run backend tests in a **new terminal**. Prepare your terminal, then run:
 
-cd src/backend
-cat django_config/local_settings.py  # review content
+```bash
+# Review local settings content
+cat django_config/local_settings.py
+
+# Grant database creation permissions for tests
 docker exec -it aapdashboard-db-1 psql -c 'ALTER USER root CREATEDB;'
 
-export PYTHONPATH=$PWD/.. # pip install -e .
+# Run tests with coverage
 pytest --cov=backend
 ```
 
 ## Frontend
+
+**Prerequisites**: Ensure the Django backend is running before starting the frontend (see backend setup above).
 
 ```bash
 nvm use v22
@@ -150,11 +284,11 @@ npx playwright install chromium
 npx playwright test --headed
 ```
 
-If only blank page is visible at URL http://localhost:9000/, check browser console for errors.
+If only blank page is visible at URL <http://localhost:9000/>, check browser console for errors.
 Error `Error: Missing API url` means VITE_API_URL is not set.
-Fix this by loading `.env` file content - `set -o allexport; source .env; set +o allexport`).
+Fix this by loading `.env` file content - `set -o allexport; source .env; set +o allexport`.
 
-## Task ManagerPerformance Tuning
+## Performance Tuning
 
 - `JOB_EVENT_WORKERS`: Number of processes for event processing (default: 4)
 - `SCHEDULE_MAX_DATA_PARSE_JOBS`: Maximum concurrent parse jobs (default: 30)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ nano clusters.yaml
 **Edit the following variables in `clusters.yaml`:**
 
 - `address`: Change to your AAP VM IP address (e.g., `10.44.17.179`)
-- `port`: Change from `8443` to `443` if needed for your AAP setup
+- `port`: Change value if your AAP API is accessible on a different TCP port.
 - `access_token`: Replace `sampleToken` with your actual AAP access token
 - Remove any unused cluster instances from the file
 

--- a/src/backend/django_config/local_settings.example.py
+++ b/src/backend/django_config/local_settings.example.py
@@ -23,9 +23,9 @@ AAP_AUTH_PROVIDER = {
     # For AAP v2.4
     "url": "aap24.example.com:8443/api",
     "user_data_endpoint": "/v2/me/",
-    # For AAP v2.5
+    # For AAP v2.5, v2.6
     # "url": "aap25.example.com",
-    # "user_data_endpoint": "/api/v2/me/",
+    # "user_data_endpoint": "/api/gateway/v1/me/",
     #
     "check_ssl": False,
     "client_id": "TODO",


### PR DESCRIPTION
As a user installing the Ansible Automation Dashboard using the local developer installation for the first time, I want the process to be as seamless as possible. As it stands now, some clarification in the README could greatly benefit new users.

 https://issues.redhat.com/browse/AAP-54505

This pr aims to provide more detailed instructions to the README, specifically for new developers who are unfamiliar with the project.

- Specify which vars in local_settings.py are changed, rather than simply saying that the content needs to be adjusted
- Specify which vars in clusters.yaml are changed
- Separate commands to start docker vs running the migrations and superuser
- Specify content of clusters.yaml file
- Each new manage command (migrations, run server, syncdata, run dispatcher, backend tests) ALL require a new terminal window, source .venv, source .env, export PYTHONPATH, etc. 
- explain that the clusters.yaml example creates a sync task. Add some info about configuring that in the yaml file.
- add clarity about what tasks need to be running before running another. For example, dispatcher is required for the syncing to actually be completed and running the django backend is required for the frontend to work properly