### PR TITLE
[AAP-55700]: Moving image from tech-preview state

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
@@ -6,7 +6,7 @@ registry_auth: true
 registry_url: registry.redhat.io
 registry_tls_verify: true
 registry_ns_aap: ansible-automation-platform-24
-registry_ns_aap_automation_dashboard: ansible-automation-platform-tech-preview
+registry_ns_aap_automation_dashboard: ansible-automation-platform
 registry_ns_rhel: rhel8
 
 ### database


### PR DESCRIPTION
The registry_ns_aap_automation_dashboard parameter is used to retrieve the dashboard image, as shown below. Since we are moving out of tech preview, this should be updated accordingly.

`    _dashboard_image_be: '{{ registry_url }}/{{ registry_ns_aap_automation_dashboard }}/{{ dashboard_image_be }}'
`