### PR TITLE
AAP-55996 Do not expose Django admin by default

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/defaults/main.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/defaults/main.yml
@@ -41,6 +41,7 @@ nginx_http_port: 8083
 nginx_https_port: 8447
 nginx_client_max_body_size: 5m
 nginx_user_headers: []
+nginx_dashboard_admin_exposed: false
 
 ### receptor
 # receptor_conf_dir: "{{ aap_volumes_dir }}/receptor/etc"

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/nginx.conf.j2
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/nginx.conf.j2
@@ -122,7 +122,12 @@ http {
         #     proxy_set_header X-Real-IP $remote_addr;
         # }
 
-        location ~ ^/(api|admin)/ {
+        {% if nginx_dashboard_admin_exposed %}
+        {% set exposed_django_urls = "api|admin" %}
+        {% else %}
+        {% set exposed_django_urls = "api" %}
+        {% endif %}
+        location ~ ^/({{ exposed_django_urls }})/ {
             # proxy_pass http://127.0.0.1:8000;
 
             # Redirect if there is no forward-slash

--- a/setup/inventory.example
+++ b/setup/inventory.example
@@ -77,3 +77,8 @@ bundle_install=false
 # Relevant if bundle_install=true
 # <full path to the bundle directory>
 bundle_dir='{{ lookup("ansible.builtin.env", "PWD") }}/bundle'
+
+# AAP Dashboard - optional
+# --------------------------
+# Set to True to expose Django admin page.
+# nginx_dashboard_admin_exposed=False


### PR DESCRIPTION
The admin page is needed only for debugging.
If required, it can be exposed via inventory variable.

https://issues.redhat.com/browse/AAP-55996