### PR TITLE
AAP-55575 Dynamic Manual Execution Time

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -533,6 +533,20 @@ def cluster_sync_data(cluster, api_jobs, api_host_summaries):
 
 
 @pytest.fixture
+def cluster_sync_data_elapsed(cluster, api_jobs, api_host_summaries):
+    data = api_jobs[1]
+    data["elapsed"] = 8965.58
+    data["host_summaries"] = [
+        api_host_summaries[1],
+        api_host_summaries[2],
+    ]
+
+    return ClusterSyncData.objects.create(
+        cluster=cluster,
+        data=data,
+    )
+
+@pytest.fixture
 def superuser():
     return User.objects.create(
         username="test",

--- a/src/backend/tests/unit/test_parser.py
+++ b/src/backend/tests/unit/test_parser.py
@@ -253,6 +253,12 @@ class TestParser:
         for key, value in expected.items():
             assert getattr(job_template, key) == value
 
+    def test_job_template_calculate_manual_execution_time(self, cluster, cluster_sync_data_elapsed):
+        parser = DataParser(cluster_sync_data_elapsed.id)
+        job_template = parser.job_template
+        assert JobTemplate.objects.count() == 1
+        assert job_template.time_taken_manually_execute_minutes == 299
+
     @pytest.mark.parametrize('expected', [
         aap_user_expected_data,
     ])


### PR DESCRIPTION
This pull request introduces logic to automatically calculate and set the manual execution time for a `JobTemplate` when no jobs exist for that template. It also adds corresponding tests and a fixture to support this new behavior. The main changes are grouped into enhancements to the parser logic and updates to the test suite.

**Enhancements to parser logic:**

* Added logic in `DataParser.job_template` to calculate and set `time_taken_manually_execute_minutes` based on the `elapsed` field when no jobs exist for the template, using rounding and boundary checks. (`src/backend/apps/clusters/parser.py`, [src/backend/apps/clusters/parser.pyL63-R84](diffhunk://#diff-f93c1f5e5e8b6c5eea3decfe487e83dc46ed66927fb6b0922780f42b1ebfb92dL63-R84))
* Imported the `decimal` module and `settings` to support the new calculation and configuration. (`src/backend/apps/clusters/parser.py`, [src/backend/apps/clusters/parser.pyR1-R4](diffhunk://#diff-f93c1f5e5e8b6c5eea3decfe487e83dc46ed66927fb6b0922780f42b1ebfb92dR1-R4))

**Test suite updates:**

* Added a new fixture `cluster_sync_data_elapsed` to provide test data with an `elapsed` value for testing the manual execution time calculation. (`src/backend/tests/conftest.py`, [src/backend/tests/conftest.pyR535-R548](diffhunk://#diff-2f574640999ddf5d1e3c1d4217f1d8d3018710f2801838edea87078a919ca77eR535-R548))
* Added a unit test `test_job_template_calculate_manual_execution_time` to verify that the manual execution time is correctly calculated and set on the `JobTemplate`. (`src/backend/tests/unit/test_parser.py`, [src/backend/tests/unit/test_parser.pyR256-R261](diffhunk://#diff-bdfebac142a30529394ece2330609e2171337e17b91636237820d5f10fa63828R256-R261))