### PR TITLE
AAP-57037 PDF download and error with maximum limit message

### DIFF
--- a/src/backend/api/v1/report/views.py
+++ b/src/backend/api/v1/report/views.py
@@ -336,7 +336,7 @@ class ReportsView(AdminOnlyViewSet, mixins.ListModelMixin, GenericViewSet):
 
     @action(methods=["post"], detail=False)
     def pdf(self, request: Request) -> WeasyTemplateResponse:
-        table_qs = self.filter_queryset(self.get_base_queryset())
+        table_qs = self.filter_queryset(self.get_base_queryset())[:settings.MAX_PDF_JOB_TEMPLATES]
 
         currency_value = Settings.currency()
         currency_sign = "$"

--- a/src/backend/api/v1/template_options/views.py
+++ b/src/backend/api/v1/template_options/views.py
@@ -28,6 +28,7 @@ from backend.apps.clusters.models import (
     Job,
     Costs, max_minutes_input, min_minutes_input)
 from backend.apps.common.models import Currency, Settings, FilterSet
+from backend.django_config import settings
 
 
 class TemplateOptionsView(AdminOnlyViewSet):
@@ -65,6 +66,7 @@ class TemplateOptionsView(AdminOnlyViewSet):
             "currency": Settings.currency(),
             "enable_template_creation_time": Settings.enable_template_creation_time(),
             "filter_sets": FilterSetSerializer(filter_sets, many=True).data,
+            "max_pdf_job_templates": settings.MAX_PDF_JOB_TEMPLATES,
         }
 
         return Response(

--- a/src/backend/django_config/settings.py
+++ b/src/backend/django_config/settings.py
@@ -348,6 +348,10 @@ INITIAL_SYNC_DAYS = 1
 # Initial sync date (overrides INITIAL_SYNC_DAYS)
 INITIAL_SYNC_SINCE = '2025-08-08'
 
+
+# PDF Download (Do not exceed the number 4000)
+MAX_PDF_JOB_TEMPLATES = 4000
+
 ### Local settings
 local_config_file = os.path.join(BASE_DIR, "django_config", "local_settings.py")
 try:

--- a/src/backend/tests/unit/test_views.py
+++ b/src/backend/tests/unit/test_views.py
@@ -14,7 +14,9 @@ from backend.apps.clusters.models import Project, JobTemplate, Costs, CostsChoic
 from backend.apps.common.models import FilterSet, Currency, Settings, SettingsChoices
 
 test_template_expected_data = {
-    'clusters': [{'id': 1, 'address': 'localhost'}],
+    'clusters': [
+        {'id': 1, 'address': 'localhost'}
+    ],
     'currencies': [
         {'id': 2, 'name': 'EUR', 'iso_code': 'EUR', 'symbol': '€'},
         {'id': 1, 'name': 'United States Dollar', 'iso_code': 'USD', 'symbol': '$'}
@@ -23,9 +25,9 @@ test_template_expected_data = {
         {'key': 2, 'value': 'Organization A', 'cluster_id': 1}
     ],
     'labels': [
-        {'cluster_id': 1, 'key': 1, 'value': 'Label A'},
-        {'cluster_id': 1, 'key': 2, 'value': 'Label B'},
-        {'cluster_id': 1, 'key': 3, 'value': 'Label C'}
+        {'key': 1, 'value': 'Label A', 'cluster_id': 1},
+        {'key': 2, 'value': 'Label B', 'cluster_id': 1},
+        {'key': 3, 'value': 'Label C', 'cluster_id': 1}
     ],
     'date_ranges': [
         {'key': 'last_year', 'value': 'Past year'},
@@ -45,14 +47,32 @@ test_template_expected_data = {
     ],
     'projects': [
         {'key': 1, 'value': 'Project A', 'cluster_id': 1},
-        {'key': 2, 'value': 'Project B', 'cluster_id': 1}],
+        {'key': 2, 'value': 'Project B', 'cluster_id': 1}
+    ],
     'manual_cost_automation': 50.0,
     'automated_process_cost': 20.0,
     'currency': 1,
     'enable_template_creation_time': True,
     'filter_sets': [
-        {'id': 1, 'name': 'Report 1', 'filters': {'date_range': 'last_month', 'organization': [1, 2]}},
-        {'id': 2, 'name': 'Report 2', 'filters': {'date_range': 'last_year', 'template': [1, 2]}}]}
+        {
+            'id': 1,
+            'name': 'Report 1',
+            'filters': {
+                'date_range': 'last_month',
+                'organization': [1, 2]
+            }
+        },
+        {
+            'id': 2,
+            'name': 'Report 2',
+            'filters': {
+                'template': [1, 2],
+                'date_range': 'last_year'
+            }
+        }
+    ],
+    'max_pdf_job_templates': 4000
+}
 
 test_report_expected_data = {
     'count': 1,
@@ -222,6 +242,7 @@ def mock_auth(superuser):
         mock_authenticate.return_value = superuser, None
         yield mock_authenticate
 
+
 @pytest.fixture(scope="function")
 def mock_auth_user(regularuser):
     with mock.patch("backend.apps.aap_auth.authentication.AAPAuthentication.authenticate") as mock_authenticate:
@@ -264,6 +285,7 @@ class TestViews:
         response = client.get("/api/v1/template_options/")
         assert response.status_code == 200
         data = response.json()
+        print(data)
         assert data == expected
 
     @pytest.mark.parametrize('expected', [test_report_expected_data])

--- a/src/frontend/app/Services/RestService.ts
+++ b/src/frontend/app/Services/RestService.ts
@@ -102,7 +102,15 @@ const exportToPDF = async (
 ): Promise<void> => {
   const queryString = buildQueryString(params);
   return api
-    .post(`api/v1/report/pdf/${queryString}`, { job_chart: jobChart, host_chart: hostChart }, { responseType: 'blob' })
+    .post(`api/v1/report/pdf/${queryString}`,
+      {
+        job_chart: jobChart,
+        host_chart: hostChart
+      },
+      {
+        responseType: 'blob',
+        timeout: 0
+      })
     .then((response) => {
       downloadAttachment(response.data as never, 'AAP_Automation_Dashboard_Report.pdf');
       Promise.resolve();

--- a/src/frontend/app/Store/filterStore.ts
+++ b/src/frontend/app/Store/filterStore.ts
@@ -39,6 +39,8 @@ const useFilterStore = create<FilterStoreState & FilterStoreActions>((set) => ({
   loading: 'idle',
   error: false,
   reloadData: false,
+  max_pdf_job_templates: 0,
+
   fetchTemplateOptions: async () => {
     const {
       setCurrencies,
@@ -73,6 +75,7 @@ const useFilterStore = create<FilterStoreState & FilterStoreActions>((set) => ({
         manualCostAutomation: data.manual_cost_automation,
         automatedProcessCost: data.automated_process_cost,
         projectOptions: data.projects,
+        max_pdf_job_templates: data.max_pdf_job_templates
       });
     } catch {
       set({ loading: 'failed', error: true });

--- a/src/frontend/app/Types/FilterTypes.ts
+++ b/src/frontend/app/Types/FilterTypes.ts
@@ -35,6 +35,7 @@ export interface FilterOptionResponse {
   currency: number;
   enable_template_creation_time: boolean;
   filter_sets: FilterSet[];
+  max_pdf_job_templates: number,
 }
 
 export interface Settings {
@@ -55,6 +56,7 @@ export interface FilterState {
   organizationOptions: FilterOption[];
   loading: 'idle' | 'pending' | 'succeeded' | 'failed';
   error: boolean;
+  max_pdf_job_templates: number,
 }
 
 export interface RequestFilter {

--- a/tests/playwright/fixtures/templateOptions.json
+++ b/tests/playwright/fixtures/templateOptions.json
@@ -756,5 +756,6 @@
                 "date_range": "last_6_month"
             }
         }
-    ]
+    ],
+    "max_pdf_job_templates": 4000
 }

--- a/tests/playwright/fixtures/templateOptionsAddReport.json
+++ b/tests/playwright/fixtures/templateOptionsAddReport.json
@@ -763,5 +763,6 @@
                 "date_range": "month_to_date"
             }
         }
-    ]
+    ],
+    "max_pdf_job_templates": 4000
 }


### PR DESCRIPTION
This pull request introduces a limit on the number of records that can be included in a PDF export from the dashboard, enforcing a maximum threshold both on the backend and the frontend. If a user attempts to export more records than allowed, the frontend now displays a user-friendly warning modal. The limit is configurable via backend settings and is surfaced to the frontend through the template options API. Several related code improvements and test fixture updates are also included.

**Backend: Enforcing and Exposing the PDF Record Limit**
- Added `MAX_PDF_JOB_TEMPLATES` (default: 4000) to `settings.py` and enforced this limit in the PDF export queryset in `report/views.py`. The limit is now also exposed in the template options API response. [[1]](diffhunk://#diff-e83378edf0d672f7836b808e2426f9314c87a854b7b2649cd681dcd1773d3016R351-R354) [[2]](diffhunk://#diff-30ff497b3a1d59d809a64894c9b126289a2f8240fd06cf4905bea17ec1cc8a52L339-R339) [[3]](diffhunk://#diff-ce6797e1e5efbee2b092fb813f2252075ba80a63b9666ceb5100c9657351b151R25) [[4]](diffhunk://#diff-ce6797e1e5efbee2b092fb813f2252075ba80a63b9666ceb5100c9657351b151R63)

**Frontend: Handling PDF Export Limit and User Feedback**
- Updated the dashboard to fetch and use the `max_pdf_job_templates` value from the backend. Before exporting to PDF, the frontend checks if the data exceeds the limit and, if so, displays a modal explaining the issue and suggesting the user apply filters. [[1]](diffhunk://#diff-b70479db66df59d8852805b96b92d3c062cdcd195632528b44613d6d41727ab5R39) [[2]](diffhunk://#diff-b70479db66df59d8852805b96b92d3c062cdcd195632528b44613d6d41727ab5R75) [[3]](diffhunk://#diff-80e6d2b4484b3684cb05be5813c1fa33719dcccf24c0f6494fb55006cb2f5082R38) [[4]](diffhunk://#diff-80e6d2b4484b3684cb05be5813c1fa33719dcccf24c0f6494fb55006cb2f5082R59) [[5]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL69-R77) [[6]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dR299-R305) [[7]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dR330-R359) [[8]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dR392)

**Service and API Improvements**
- Updated the `RestService.exportToPDF` method to set an unlimited timeout for PDF downloads, accommodating larger reports up to the new limit.

**Test Fixture Updates**
- Updated Playwright test fixtures to include the new `max_pdf_job_templates` field, ensuring tests reflect the backend/frontend contract. [[1]](diffhunk://#diff-8c20b7dfdf469d3d6ff39fe3e9dc99d22ccc38d2ba62fcd15c73fafb53dadb37L759-R760) [[2]](diffhunk://#diff-63eb61842b2e8f67994c6ef323ff9a07b7418ef79d3da752b665da702ab5b7b8L766-R767)

**Code Quality and Consistency**
- Minor code and import cleanups in the dashboard for improved readability and consistency. [[1]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL7-R7) [[2]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL18-R26) [[3]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL54-R54) [[4]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL114-R115) [[5]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL139-R140) [[6]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL238-R260) [[7]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dL287-R288) [[8]](diffhunk://#diff-08f3db92c081412f918131e50fbafe46aa9e2b5b77f23f3d593e8ff34109a11dR373)

These changes together ensure that large PDF exports are handled gracefully and that users are clearly informed when their request exceeds system limits.