### PR TITLE
AAP-56812 Update logging to show WARNING instead of ERROR

### DIFF
--- a/src/backend/apps/aap_auth/aap_auth.py
+++ b/src/backend/apps/aap_auth/aap_auth.py
@@ -122,7 +122,6 @@ class AAPAuth:
             timeout=30,
         )
         if not response.ok:
-            print(response.status_code)
             logger.error("An error occurred obtaining AAP token. %s", response.content)
             raise AuthenticationFailed("Obtaining of AAP token failed. An error occurred connecting to AAP authorization server.")
 

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -83,7 +83,7 @@ class Cluster(CreatUpdateModel):
                 status__in=[JobStatusChoices.PENDING, JobStatusChoices.WAITING, JobStatusChoices.RUNNING],
                 type=SyncJobTypeChoices.SYNC_JOBS
         ).count() > 0:
-            logger.error(
+            logger.warning(
                 "Sync Job template %s could not be started because there are more than %s other jobs from that template waiting to run"
                 % (self, 1)
             )
@@ -287,7 +287,7 @@ class ClusterSyncData(CreatUpdateModel):
                 cluster=self.cluster,
                 status__in=[JobStatusChoices.PENDING, JobStatusChoices.WAITING, JobStatusChoices.RUNNING],
                 type=SyncJobTypeChoices.PARSE_JOB_DATA).count() >= limit:
-            logger.error(
+            logger.warning(
                 "Parse job data %s could not be started because there are more than %s other jobs from that template waiting to run"
                 % (self, limit)
             )


### PR DESCRIPTION
This pull request makes minor improvements to error handling and logging in the authentication and job management code. The main changes involve adjusting the log level for certain messages and removing unnecessary print statements.

Logging improvements:

* Changed logging from `error` to `warning` for cases where job execution is blocked due to existing jobs, making the log level more appropriate for these expected situations in `clusters/models.py`. [[1]](diffhunk://#diff-bc013964f66a1edcf87f90c49d7b49f9e9029318ee9ce08fe416dbb5c2d50a78L86-R86) [[2]](diffhunk://#diff-bc013964f66a1edcf87f90c49d7b49f9e9029318ee9ce08fe416dbb5c2d50a78L290-R290)

Error handling cleanup:

* Removed an unnecessary `print` statement for HTTP status codes during AAP token retrieval, relying instead on structured logging for error reporting in `aap_auth.py`.