### PR TITLE
syncdata shows error if user cann't be asked for confirmation

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -120,7 +120,7 @@ cp clusters.example.yaml clusters.yaml
 nano clusters.yaml
 podman cp clusters.yaml automation-dashboard-web:/
 podman exec automation-dashboard-web /venv/bin/python ./manage.py setclusters /clusters.yaml
-podman exec automation-dashboard-web /venv/bin/python ./manage.py syncdata --since=2025-01-01 --until=2025-03-01
+podman exec -it automation-dashboard-web /venv/bin/python ./manage.py syncdata --since=2025-01-01 --until=2025-03-01
 # periodic sync executes every one hour - environ CRON_SYNC="0 */1 * * *"
 ```
 

--- a/src/backend/apps/clusters/management/commands/syncdata.py
+++ b/src/backend/apps/clusters/management/commands/syncdata.py
@@ -34,7 +34,12 @@ class Command(BaseCommand):
         _until = options.get('until') or None
 
         if _since is None or _until is None:
-            confirm = input('Interval not specified. Syncing data may take a long time. Continue Y/N:')
+            try:
+                confirm = input('Interval not specified. Syncing data may take a long time. Continue Y/N:')
+            except EOFError:
+                # We get EOFError if "podman run ..." is used without "-it"
+                self.stdout.write(self.style.ERROR('\nERROR: Non-iteractive mode, both "since" and "until" options are mandatory.'))
+                sys.exit(1)
             if confirm != 'Y':
                 sys.exit(1)
 


### PR DESCRIPTION
`userdata.py` failed with EOFError if it was run with `podman exec` without `-it` - the `input` could not read from terminal.

PR detects EOFError, and shows extra message to user before exit.
The docs are updated to suggest  `podman exec -it ...` usage.

documentation update needed