### PR TITLE
Updated registry_ns_aap_automation_dashboard

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
@@ -6,7 +6,7 @@ registry_auth: true
 registry_url: registry.redhat.io
 registry_tls_verify: true
 registry_ns_aap: ansible-automation-platform-24
-registry_ns_aap_automation_dashboard: ansible-automation-platform-tech-preview
+registry_ns_aap_automation_dashboard: ansible-automation-platform
 registry_ns_rhel: rhel8
 
 ### database


### PR DESCRIPTION
Updating the containerised installer setup defaults following the changes in konflux to move to GA from Tech-Preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `registry_ns_aap_automation_dashboard` from `ansible-automation-platform-tech-preview` to `ansible-automation-platform`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed80c0c93c1ff849386b2bea9c1df7f2d8304dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->