### PR TITLE
AAP-60695 Fix local bundle build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -92,7 +92,12 @@ jobs:
           bundle_dir=$PWD/setup/bundle
           EOF
       - name: Build bundled installer
-        run: AAP_DASHBOARD_BUNDLED_INSTALLER=1 USE_QUAY_IO_IMAGE=1 QUAY_IO_IMAGE_TAG=${{ github.ref_name }} setup/build_installer.sh
+        run: >
+          AAP_DASHBOARD_BUNDLED_INSTALLER=1
+          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
+          USE_QUAY_IO_IMAGE=1
+          QUAY_IO_IMAGE_TAG=${{ github.ref_name }}
+          setup/build_installer.sh
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4
         with:
@@ -109,7 +114,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Build online installer
-        run: AAP_DASHBOARD_BUNDLED_INSTALLER=0 USE_QUAY_IO_IMAGE=1 QUAY_IO_IMAGE_TAG=${{ github.ref_name }} setup/build_installer.sh
+        run: >
+          AAP_DASHBOARD_BUNDLED_INSTALLER=0
+          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
+          USE_QUAY_IO_IMAGE=1
+          QUAY_IO_IMAGE_TAG=${{ github.ref_name }}
+          setup/build_installer.sh
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/setup/README.md
+++ b/setup/README.md
@@ -22,7 +22,7 @@ podman login registry.redhat.io -u USERNAME
 Build image:
 
 ```bash
-podman build -f docker/Dockerfile.backend -t registry.redhat.io/ansible-automation-platform-24/automation-dashboard:latest .
+podman build -f docker/Dockerfile.backend -t registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest .
 ```
 
 Run installer.

--- a/setup/build_installer.sh
+++ b/setup/build_installer.sh
@@ -9,19 +9,42 @@ AAP_DASHBOARD_BUNDLED_INSTALLER="${AAP_DASHBOARD_BUNDLED_INSTALLER:-1}"
 AAP_DASHBOARD_IMAGE="${AAP_DASHBOARD_IMAGE:-registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest}"
 # AAP_DASHBOARD_IMAGE="${AAP_DASHBOARD_IMAGE:-quay.io/aap/automation-dashboard:latest}"
 
-# Building in GHA: we want to use the container image already built by GHA.
+# Building in GHA:
+# USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=1 USE_QUAY_IO_IMAGE=1
+# We want to use the container image already built by GHA.
 # We just need to pull existing image from quay.io, and tag it with different name.
+# Note: this cannot produce online installer that would use quay.io image!
+#
+# Building locally:
+# USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=1
+# We build the container image locally.
+# We do not push to/pull from quay.io.
+
+USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE="${USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE:-0}"
 USE_QUAY_IO_IMAGE="${USE_QUAY_IO_IMAGE:-0}"
 QUAY_IO_IMAGE_TAG="${QUAY_IO_IMAGE_TAG:-main}"
 
 function build_or_pull_container_image() {
-  if [ "$USE_QUAY_IO_IMAGE" == "0" ]
+  if [ "$USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE" == "0" ]
   then
-    ansible-playbook -i inventory ansible.containerized_installer.util_podman_login
-    podman build -f ../docker/Dockerfile.backend -t $AAP_DASHBOARD_IMAGE .. # --no-cache
+    # Use real image from registry.redhat.io.
+    # Usable for online or bundled installer.
+    podman pull $AAP_DASHBOARD_IMAGE
   else
-    podman pull quay.io/aap/automation-dashboard:$QUAY_IO_IMAGE_TAG
-    podman tag quay.io/aap/automation-dashboard:$QUAY_IO_IMAGE_TAG $AAP_DASHBOARD_IMAGE
+    if [ "$USE_QUAY_IO_IMAGE" == "1" ]
+    then
+      # Pull image from quay.io,
+      # rename it to registry.redhat.io/...,
+      # include it into bundled installer.
+      echo "Pulling quay.io/aap/automation-dashboard:$QUAY_IO_IMAGE_TAG image"
+      podman pull quay.io/aap/automation-dashboard:$QUAY_IO_IMAGE_TAG
+      podman tag quay.io/aap/automation-dashboard:$QUAY_IO_IMAGE_TAG $AAP_DASHBOARD_IMAGE
+    else
+      # Build image, include it into bundled installer.
+      echo "Building $AAP_DASHBOARD_IMAGE image"
+      ansible-playbook -i inventory ansible.containerized_installer.util_podman_login
+      podman build -f ../docker/Dockerfile.backend -t $AAP_DASHBOARD_IMAGE .. # --no-cache
+    fi
   fi
 }
 
@@ -50,6 +73,7 @@ Build configuration:
   AAP_DASHBOARD_IMAGE=$AAP_DASHBOARD_IMAGE
   USE_QUAY_IO_IMAGE=$USE_QUAY_IO_IMAGE
   QUAY_IO_IMAGE_TAG=$QUAY_IO_IMAGE_TAG
+  USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=$USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE
 EOF
 cd setup/
 if [ "$AAP_DASHBOARD_BUNDLED_INSTALLER" == "1" ]

--- a/setup/build_installer.sh
+++ b/setup/build_installer.sh
@@ -6,7 +6,7 @@ AAP_DASHBOARD_BUNDLED_INSTALLER="${AAP_DASHBOARD_BUNDLED_INSTALLER:-1}"
 
 # GHA pushes to quay.io/aap/automation-dashboard:latest,
 # but all other images are at registry.redhat.io.
-AAP_DASHBOARD_IMAGE="${AAP_DASHBOARD_IMAGE:-registry.redhat.io/ansible-automation-platform-24/automation-dashboard:latest}"
+AAP_DASHBOARD_IMAGE="${AAP_DASHBOARD_IMAGE:-registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest}"
 # AAP_DASHBOARD_IMAGE="${AAP_DASHBOARD_IMAGE:-quay.io/aap/automation-dashboard:latest}"
 
 # Building in GHA: we want to use the container image already built by GHA.

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/bundle.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/bundle.yml
@@ -52,7 +52,7 @@
     force: '{{ container_image_update }}'
     validate_certs: '{{ registry_tls_verify }}'
     arch: '{{ container_image_arch | default(omit) }}'
-  loop: '{{ _images | union((__de_images | default([])) | union(__ee_images | default([]))) | unique }}'
+  loop: '{{ _images_to_pull_into_bundle | union((__de_images | default([])) | union(__ee_images | default([]))) | unique }}'
   environment:
     HTTP_PROXY: "{{ http_proxy | default('') }}"
     HTTPS_PROXY: "{{ https_proxy | default('') }}"

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/images.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/images.yml
@@ -57,6 +57,16 @@
     _images: '{{ _images | default([]) | union([_dashboard_image_be]) }}'
   when: inventory_hostname in groups.get('automationdashboard', [])
 
+- name: Set which images should be pulled - if dashboard image is pulled from registry
+  ansible.builtin.set_fact:
+    _images_to_pull_into_bundle: '{{ _images | default([]) }}'
+  when: lookup('ansible.builtin.env', 'USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE', default='0') == '0'
+
+- name: Set which images should be pulled - if dashboard image is locally built
+  ansible.builtin.set_fact:
+    _images_to_pull_into_bundle: '{{ _images | default([]) | reject("eq", _dashboard_image_be) | list }}'
+  when: lookup('ansible.builtin.env', 'USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE', default='0') == '1'
+
 - name: Add DE images to the list
   ansible.builtin.set_fact:
     __de_images: '{{ __de_images | default([]) | union([_de_supported_image]) }}'


### PR DESCRIPTION
PR adds an option to build (bundled) installer locally, without pushing built image to external registry. It is handy for testing.

Default image name is changed to "registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest" in 2 places. This was done in some other places before (3c77761a952eefd450670a744f07c903a9a5563e).