### PR TITLE
AAP-60302 Document certificate verification options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ nano clusters.yaml
 - `rrule`: A recurrence rule (RFC 5545 format) that defines when syncing occurs
 - `enabled`: Whether this sync schedule is active
 
+**An AAP with a self-signed TLS certificate** is selected with the option `verify_ssl: false`.
+The option can be changed to `verify_ssl: true` if your AAP uses a real, commercial certificate.
+Currently there is no option to connect to an AAP with a self-signed certificate and to verify this certificate
+(e.g. a self-signed certificate for AAP is issued by a custom CA authority,
+and automation dashboard verifies the certificate belongs to the custom CA authority).
+
 Example configuration:
 
 ```yaml

--- a/setup/README.md
+++ b/setup/README.md
@@ -113,6 +113,22 @@ ansible-galaxy collection install -r requirements.yml
 ansible-playbook -i inventory ansible.containerized_installer.dashboard_install
 ```
 
+##### TLS certificate for automation dashboard
+
+By default, a self-signed TLS certificate is generated when `ansible-playbook ansible.containerized_installer.dashboard_install` is run.
+
+A commercial certificate can be optionally configured.
+In `inventory` file two variables need to be set:
+
+ - `dashboard_tls_key`
+ - `dashboard_tls_cert`
+
+The `dashboard_tls_key` is a private TLS key.
+
+The `dashboard_tls_cert` is a public TLS certificate.
+It must include server certificate, intermediate CA certificates and root CA certificate.
+**Note**: the server certificate must be the at the beginning of the `dashboard_tls_cert` file.
+
 #### Configure application
 
 ```bash


### PR DESCRIPTION
Document certificate verification options. The automation dashboard can be deployed with selfsigned or commercial certifiacte.

The AAP URLs need to use commercial certificate, or TLS verifiction is disabled. The automation dashboard is not able to verify AAP URL against custom CA chain.