### PR TITLE
Fix GHA building bundled installer

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build bundled installer
         run: >
           AAP_DASHBOARD_BUNDLED_INSTALLER=1
-          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
+          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=1
           USE_QUAY_IO_IMAGE=1
           QUAY_IO_IMAGE_TAG=${{ github.ref_name }}
           setup/build_installer.sh
@@ -116,7 +116,7 @@ jobs:
       - name: Build online installer
         run: >
           AAP_DASHBOARD_BUNDLED_INSTALLER=0
-          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
+          USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=1
           USE_QUAY_IO_IMAGE=1
           QUAY_IO_IMAGE_TAG=${{ github.ref_name }}
           setup/build_installer.sh


### PR DESCRIPTION
The GHA needs to pull quay.io image, and
tag this local image with registy.redhat.io/... name.

Fixes this failure
https://github.com/ansible/automation-reports/actions/runs/20266618424/job/58191578305