### PR TITLE
Fix typo in ansible taks

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/systemd.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/systemd.yml
@@ -6,7 +6,7 @@
     enabled: true
     scope: user
     daemon_reload: true
-    ignore_errors: true
+  ignore_errors: true
   loop: '{{ __services }}'
 
 - name: Ensure automation dashboard containers are enabled and started - without deamon_reload


### PR DESCRIPTION
Fix typo, there were 2 extra spaces - wrong indent.