### PR TITLE
[AAP-62041] [AAP-62422] Update urllib3 library

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1418,9 +1418,9 @@ uritemplate==4.2.0 \
     --hash=sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e \
     --hash=sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686
     # via drf-spectacular
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.3 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
     # via
     #   -r requirements-pinned.txt
     #   requests

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -22,7 +22,7 @@ requests==2.32.5
 setuptools==80.9.0
 split-settings==1.0.0
 tzdata==2025.3
-urllib3==2.5.0
+urllib3==2.6.3
 uvicorn==0.38.0
 drf-spectacular==0.29.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ requests==2.32.5
 setuptools==80.9.0
 split-settings==1.0.0
 tzdata==2025.3
-urllib3==2.5.0
+urllib3==2.6.3
 uvicorn==0.38.0
 drf-spectacular==0.29.0


### PR DESCRIPTION
This pull request updates the `urllib3` dependency to version 2.6.3 in both the build and pinned requirements files. This ensures the project uses the latest compatible version of `urllib3`, which may include important bug fixes and security updates.

Dependency updates:

* Upgraded `urllib3` from version 2.5.0 to 2.6.3 in `requirements-build.txt` and updated the associated hash values.
* Upgraded `urllib3` from version 2.5.0 to 2.6.3 in `requirements-pinned.txt`.

cc: @justinc1 