### PR TITLE
AAP-58983 store OAuth2 client_secret as podman secret

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
@@ -35,6 +35,7 @@
     _common_secrets:
       - 'dashboard_secret_key,target=/etc/dashboard/SECRET_KEY,mode=0400,uid={{ ansible_user_uid }}'
       - 'dashboard_database_key,target=/etc/dashboard/DATABASE_KEY,mode=0400,uid={{ ansible_user_uid }}'
+      - 'dashboard_aap_auth_provider_client_secret,target=/etc/dashboard/AAP_AUTH_PROVIDER_CLIENT_SECRET,mode=0400,uid={{ ansible_user_uid }}'
       # - 'dashboard_channels,target=/etc/tower/conf.d/channels.py,mode=0400,uid={{ ansible_user_uid }}'
       - 'dashboard_postgres,target=/etc/dashboard/conf.d/postgres.py,mode=0400,uid={{ ansible_user_uid }}'
     _common_volumes:

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/secrets.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/secrets.yml
@@ -31,4 +31,15 @@
     # - Restart dashboard rsyslog
     - Restart dashboard task
     - Restart dashboard web
+
+- name: Create the dashboard AAP_AUTH_PROVIDER_CLIENT_SECRET secret
+  containers.podman.podman_secret:
+    name: dashboard_aap_auth_provider_client_secret
+    data: '{{ aap_auth_provider_client_secret }}'
+    force: true
+    skip_existing: false
+  notify:
+    # - Restart dashboard rsyslog
+    - Restart dashboard task
+    - Restart dashboard web
 ...

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/django_dashboard_conf.py.j2
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/templates/django_dashboard_conf.py.j2
@@ -2,6 +2,8 @@ with open("/etc/dashboard/SECRET_KEY") as fin:
     SECRET_KEY = fin.read()
 with open("/etc/dashboard/DATABASE_KEY") as fin:
     DATABASE_KEY = fin.read()
+with open("/etc/dashboard/AAP_AUTH_PROVIDER_CLIENT_SECRET") as fin:
+    AAP_AUTH_PROVIDER_CLIENT_SECRET = fin.read()
 
 ALLOWED_HOSTS=["*"]
 CORS_ALLOWED_ORIGINS = [
@@ -28,7 +30,7 @@ AAP_AUTH_PROVIDER = {
     "user_data_endpoint": "{{ __aap_auth_provider_user_data_endpoint }}",
     "check_ssl": "{{ aap_auth_provider_check_ssl }}",
     "client_id": "{{ aap_auth_provider_client_id }}",
-    "client_secret": "{{ aap_auth_provider_client_secret }}",
+    "client_secret": AAP_AUTH_PROVIDER_CLIENT_SECRET,
 }
 
 # Initial sync timedelta in days


### PR DESCRIPTION
Before PR, the `client_secret` was visible on podman host in a file. PR changes this, client_secret is stored as podman secret. The content is available only inside container.