### PR TITLE
Revert "AAP-60515 switch to pull_request_target for github workflows using secrets"

### DIFF
--- a/.github/workflows/sync-requirements.yml
+++ b/.github/workflows/sync-requirements.yml
@@ -5,7 +5,7 @@ on:
         branches: [main]
         paths:
             - "requirements-pinned.txt"
-    pull_request_target:
+    pull_request:
         paths:
             - "requirements-pinned.txt"
 
@@ -18,26 +18,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: "Checkout automation-reports (${{ github.ref }}) - tested repo, PR"
-              if: github.event_name == 'pull_request_target'
+            - name: "Checkout automation-reports (${{ github.ref }})"
               uses: actions/checkout@v5
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  path: test-repo
-
-            - name: "Checkout automation-reports (${{ github.ref }}) - tested repo, push to main"
-              if: github.event_name == 'push'
-              uses: actions/checkout@v5
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  path: test-repo
-
-            - name: "Checkout automation-reports (${{ github.ref }}) - main repo"
-              uses: actions/checkout@v5
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  path: main-repo
 
             - name: "Set up Python"
               uses: actions/setup-python@v5
@@ -51,14 +35,12 @@ jobs:
 
             - name: "Sync requirements files"
               run: |
-                  chmod +x main-repo/sync-requirements.sh
-                  cd test-repo
-                  ../main-repo/sync-requirements.sh
+                  chmod +x sync-requirements.sh
+                  ./sync-requirements.sh
 
             - name: "Check for changes"
               id: changes
               run: |
-                  cd test-repo
                   if ! git diff --quiet requirements-build.txt; then
                     echo "changed=true" >> $GITHUB_OUTPUT
                     echo "Requirements-build.txt has been updated"
@@ -70,7 +52,6 @@ jobs:
             - name: "Commit and push changes"
               if: steps.changes.outputs.changed == 'true' && github.event_name == 'push'
               run: |
-                  cd test-repo
                   git config --local user.email "action@github.com"
                   git config --local user.name "GitHub Action"
                   git add requirements-build.txt
@@ -78,7 +59,7 @@ jobs:
                   git push
 
             - name: "Add PR comment for changes"
-              if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request_target'
+              if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request'
               uses: actions/github-script@v7
               with:
                   script: |
@@ -90,9 +71,8 @@ jobs:
                       })
 
             - name: "Fail if requirements out of sync in PR"
-              if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request_target'
+              if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request'
               run: |
-                  cd test-repo
                   echo "Requirements-build.txt is out of sync. Please run 'make sync-requirements' locally and commit the changes."
                   git diff requirements-build.txt
                   exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,6 +61,13 @@ jobs:
           export PYTHONPATH=$PWD/..
           pytest --cov=backend --cov-report=term-missing:skip-covered --cov-report=xml:coverage-backend.xml
 
+      - name: Get Cover
+        uses: orgoro/coverage@v3.2
+        with:
+            coverageFile: src/backend/coverage-backend.xml
+            token: ${{ secrets.GITHUB_TOKEN }}
+            sourceDir: src/backend
+
       - name: Inject PR number into coverage.xml
         if: >-
           !cancelled()


### PR DESCRIPTION
Reverts ansible/automation-reports#204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> This PR reworks CI workflows to remove `pull_request_target` usage and streamline requirements syncing, and adds backend coverage reporting.
> 
> - **Sync Requirements workflow:** switch trigger from `pull_request_target` to `pull_request`, collapse multiple checkouts into a single `actions/checkout` use, run `sync-requirements.sh` from repo root, and update PR comment/fail conditions to `pull_request`.
> - **Unit Tests workflow:** add `orgoro/coverage@v3.2` step to publish coverage from `src/backend/coverage-backend.xml`; keep PR-number injection for coverage XML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 748238d5c93a921ed46d419698a6f52d0270edb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->