### PR TITLE
Updated cpe label in dockerfile

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -44,6 +44,8 @@ ENV DESCRIPTION="Red Hat Automation Platform - dashboard backend \
 
 LABEL description="$DESCRIPTION"
 
+LABEL cpe="cpe:/a:redhat:ansible_automation_platform:2.5::el9"
+
 USER root
 
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
Required by Release Engineering to prevent image being mistaken for generic RHEL-9 image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds required image metadata to improve identification of the backend container image.
> 
> - Adds `LABEL cpe="cpe:/a:redhat:ansible_automation_platform:2.5::el9"` to `docker/Dockerfile.backend` alongside the existing `description` label
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51282cd12fbf98fbce9dcd73b69f92b5ad182075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->