### PR TITLE
AAP-62164 Optionally use arbitrary automation dashboard image

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/defaults/main.yml
@@ -4,6 +4,7 @@ bundle_install: false
 ### registry variables
 registry_auth: true
 registry_url: registry.redhat.io
+registry_url_aap_automation_dashboard: registry.redhat.io
 registry_tls_verify: true
 registry_ns_aap: ansible-automation-platform-24
 registry_ns_aap_automation_dashboard: ansible-automation-platform

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/images.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/images.yml
@@ -13,7 +13,7 @@
     _postgresql_image: '{{ registry_url }}/{{ registry_ns_rhel }}/{{ postgresql_image }}'
     _receptor_image: '{{ registry_url }}/{{ registry_ns_aap }}/{{ receptor_image }}'
     _redis_image: '{{ registry_url }}/{{ registry_ns_rhel }}/{{ redis_image }}'
-    _dashboard_image_be: '{{ registry_url }}/{{ registry_ns_aap_automation_dashboard }}/{{ dashboard_image_be }}'
+    _dashboard_image_be: '{{ registry_url_aap_automation_dashboard }}/{{ registry_ns_aap_automation_dashboard }}/{{ dashboard_image_be }}'
 
   run_once: true
 


### PR DESCRIPTION
Dedicated variables only for automation dashboard image. This allows testing non-production images.