### PR TITLE
AAP-62164 .env files must not be a shell script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,5 @@
-# Save current allexport state and enable it
-push_allexport() {
-    case "$(set -o | grep allexport)" in
-        *on)  __old_allexport=on  ;;
-        *off) __old_allexport=off ;;
-    esac
-    set -o allexport
-}
-
-# Restore previous allexport state
-pop_allexport() {
-    if [ "$__old_allexport" = on ]; then
-        set -o allexport
-    else
-        set +o allexport
-    fi
-    unset __old_allexport
-}
-
-push_allexport
+# This MUST be a plain .env file.
+# It is not a shell script.
 
 VITE_API_URL=http://localhost:8000
 DATA_REFRESH_INTERVAL_SECONDS=60
@@ -27,5 +9,3 @@ DB_USER=root
 DB_PASSWORD=TODO
 DB_HOST=localhost
 DB_PORT=5432
-
-pop_allexport

--- a/.env.sh
+++ b/.env.sh
@@ -20,9 +20,14 @@ pop_allexport() {
 # we do "source this_script.sh"
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 pushd "$SCRIPT_DIR"
+# Load environment variables
 push_allexport
 source .env
 pop_allexport
+# Activate virtual environment
+source .venv/bin/activate
+# Set Python path
+export PYTHONPATH=$PWD/src
 popd
 
 echo DB_NAME=$DB_NAME

--- a/.env.sh
+++ b/.env.sh
@@ -1,0 +1,28 @@
+# Save current allexport state and enable it
+push_allexport() {
+    case "$(set -o | grep allexport)" in
+        *on)  __old_allexport=on  ;;
+        *off) __old_allexport=off ;;
+    esac
+    set -o allexport
+}
+
+# Restore previous allexport state
+pop_allexport() {
+    if [ "$__old_allexport" = on ]; then
+        set -o allexport
+    else
+        set +o allexport
+    fi
+    unset __old_allexport
+}
+
+# we do "source this_script.sh"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+pushd "$SCRIPT_DIR"
+push_allexport
+source .env
+pop_allexport
+popd
+
+echo DB_NAME=$DB_NAME

--- a/README.md
+++ b/README.md
@@ -71,21 +71,23 @@ sudo dnf install python3.12-devel libpq-devel
 
 ### Common Terminal Setup
 
-Throughout this guide, you'll need to prepare your terminal environment. Here's the standard pattern:
+Throughout this guide, you'll need to prepare your terminal environment.
+This assumes you already:
+
+- created python virtual environment in .venv
+- created .env file
+
+Here's the standard pattern:
 
 ```bash
 # Navigate to project directory
 cd /path/to/automation-reports
 
-# Activate virtual environment
-source .venv/bin/activate
+# Load environment variables, activate virtual environment, set Python path
+source .env.sh
 
-# Load environment variables
-source .env
-
-# Navigate to backend and set Python path
+# Navigate to backend
 cd src/backend
-export PYTHONPATH=$PWD/..
 ```
 
 **Note:** The sections below will reference "prepare your terminal" to mean running these commands.
@@ -347,7 +349,7 @@ npx playwright test --headed
 
 If only blank page is visible at URL <http://localhost:9000/>, check browser console for errors.
 Error `Error: Missing API url` means VITE_API_URL is not set.
-Fix this by loading `.env` file content - `set -o allexport; source .env; set +o allexport`.
+Fix this by loading environ variables - `source .env.sh`.
 
 ## Performance Tuning
 


### PR DESCRIPTION
docker compose uses .env, so this file must not be a shell script. Make it a plain .env file.

PR also adds .env.sh helper, to simplify common terminal setup before running tests etc.
