### PR TITLE
AAP-61957 CI fix path to coverage-backend.xml

### DIFF
--- a/.github/workflows/sonar-checks.yml
+++ b/.github/workflows/sonar-checks.yml
@@ -70,7 +70,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
         with:
           args: >
-            -Dsonar.python.coverage.reportPaths=src/backend/coverage-backend.xml
+            -Dsonar.python.coverage.reportPaths=coverage-backend.xml
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
             -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
             -Dsonar.pullrequest.branch=${{ env.PR_HEAD }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -79,9 +79,11 @@ jobs:
 
       - name: Save off PR Number
         run: echo "PR ${{ github.event.number }}" > pr_number.txt
+        if: github.event_name == 'pull_request'
 
       - name: Upload PR Number
         uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
         with:
           name: pr_number
           path: pr_number.txt


### PR DESCRIPTION
When coverage-backend.xml is extracted, its parent directories are removed. Sonarcube then complained (https://github.com/ansible/automation-reports/actions/runs/21510582484/job/61976378660#step:9:165):

```
09:14:33.023 WARN  No report was found for sonar.python.coverage.reportPaths using pattern src/backend/coverage-backend.xml
```

https://github.com/ansible/automation-reports/actions/runs/21514726271/job/61990287954 - where is actually coverage-backend.xml.

There is no need to upload pr_number.txt if there is no PR.
