### PR TITLE
AAP-64949 gracefuly handle errors when removing clusters.yaml file

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -134,9 +134,8 @@ It must include server certificate, intermediate CA certificates and root CA cer
 ```bash
 cp clusters.example.yaml clusters.yaml
 nano clusters.yaml
-podman cp clusters.yaml automation-dashboard-web:/
-podman exec automation-dashboard-web /venv/bin/python ./manage.py setclusters /clusters.yaml
-podman exec automation-dashboard-web /bin/rm /clusters.yaml
+podman cp clusters.yaml automation-dashboard-web:/tmp/
+podman exec automation-dashboard-web /venv/bin/python ./manage.py setclusters /tmp/clusters.yaml
 podman exec -it automation-dashboard-web /venv/bin/python ./manage.py syncdata --since=2025-01-01 --until=2025-03-01
 # periodic sync executes every one hour - environ CRON_SYNC="0 */1 * * *"
 ```

--- a/src/backend/apps/clusters/management/commands/setclusters.py
+++ b/src/backend/apps/clusters/management/commands/setclusters.py
@@ -184,4 +184,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS('Successfully set up AAP clusters'))
         if not keep_file:
             self.stdout.write(self.style.NOTICE(f'Removing file {path}'))
-            os.remove(path)
+            try:
+                os.remove(path)
+            except Exception as ex:
+                self.stdout.write(self.style.ERROR(f'Error removing file {path}: {ex}'))


### PR DESCRIPTION
We need to put clusters.yaml file into container /tmp if we want to remove it later from inside of container.

If remove fails, report error back to user, and continue.

Requires doc update.