### PR TITLE
AAP-65874 Do not retag quay.io image as registry.redhat.io image

### DIFF
--- a/docker/Dockerfile.backend.dockerignore
+++ b/docker/Dockerfile.backend.dockerignore
@@ -1,1 +1,2 @@
 # src/frontend/
+src/backend/django_config/local_settings.py


### PR DESCRIPTION
Image "rename" makes debugging difficult. The `podman ps` tells you `registry.redhat.io` is used. But bundled installer actually included say `quay.io` image, but renamed before `podman save`-ing it.

The `registry_url_aap_automation_dashboard` and `registry_ns_aap_automation_dashboard` ansible vars were added, so installer can now use images from different registry/namespace than postgres and redis image. This is what PR implements.

Also, do not include local_settings.py into bundled installer. Podman somehow ignored the Dockerfile.backend.dockerignore file, we need to add it explicitly to cmdline.

I'm not sure how is `setup/build_installer.sh` used in downstream build (if it is used at all). But I'm worried this could break downstream build, so I added a few extra reviewers. I did not rename existing env vars in the script, but PR moves AAP_DASHBOARD_IMAGE var inside the script. It should still allow creating a bundled installer for registry.redhat.io or stage.registry.redhat.io. Honestly, I think this script should be simplified - the env vars and how to use them, it is a bit akward.