### PR TITLE
AAP-62946: Fix parse task deadlock caused by null started time in AAP job data

### DIFF
--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -119,8 +119,8 @@ class ApiConnector:
                 verify=self.cluster.verify_ssl,
                 timeout=timeout if timeout is not None else self.timeout,
                 headers=headers)
-        except requests.exceptions.RequestException as e:
-            logger.error(f'Token refresh POST request failed with exception {e}')
+        except requests.exceptions.RequestException:
+            logger.exception('Token refresh POST request failed')
             return False
         if not response.ok:
             logger.error(
@@ -158,8 +158,8 @@ class ApiConnector:
             if isinstance(e_inner, str) and e_inner.startswith("Connection refused by Responses - "):
                 raise
             # end mock testing block ------------------------
-        except requests.exceptions.RequestException as e:
-            logger.error(f'GET request failed with exception {e}')
+        except requests.exceptions.RequestException:
+            logger.exception('GET request failed')
             return None
         logger.debug(f"First GET response status: {response.status_code}")
         if response.ok:
@@ -173,8 +173,8 @@ class ApiConnector:
 
         try:
             response = self._get_request(url, timeout)
-        except requests.exceptions.RequestException as e:
-            logger.error(f'GET request failed with exception {e}')
+        except requests.exceptions.RequestException:
+            logger.exception('GET request failed')
             return None
         logger.debug(f"Second GET response status: {response.status_code}")
         return response
@@ -315,8 +315,8 @@ class ApiConnector:
                 verify=self.cluster.verify_ssl,
                 timeout=timeout,
                 headers=self.headers)
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Ping request failed: {e}")
+        except requests.exceptions.RequestException:
+            logger.exception('Ping request failed')
             return None
         if response is None or not response.ok:
             logger.warning(f"Ping to {url} failed or returned no response.")
@@ -366,6 +366,8 @@ class ApiConnector:
             if job_id is None or finished is None:
                 logger.warning(f"Missing id or finished date time in job: {job}")
                 continue
+            if job.get("started") is None:
+                logger.info(f"Job {job_id} has null started time (status={job.get('status')}); ingesting with started=None")
             try:
                 finished = datetime.datetime.fromisoformat(finished).astimezone(datetime.timezone.utc)
             except ValueError:

--- a/src/backend/apps/dispatch/management/commands/run_dispatcher.py
+++ b/src/backend/apps/dispatch/management/commands/run_dispatcher.py
@@ -75,9 +75,23 @@ class Command(BaseCommand):
                 results.append(result)
             logger.debug('Tasks: %s', results)
             return
+        self._reset_interrupted_jobs()
+
         try:
             DispatcherMetricsServer().start()
         except redis.exceptions.ConnectionError as exc:
             raise CommandError(f'Dispatcher could not connect to redis, error: {exc}')
 
         run_service()
+
+    def _reset_interrupted_jobs(self):
+        from backend.apps.clusters.models import JobStatusChoices
+        from backend.apps.scheduler.models import SyncJob, JobTypeChoices
+
+        stuck_statuses = [JobStatusChoices.RUNNING, JobStatusChoices.PENDING, JobStatusChoices.WAITING]
+        count = SyncJob.objects.filter(type=JobTypeChoices.PARSE_JOB_DATA, status__in=stuck_statuses).update(
+            status=JobStatusChoices.FAILED,
+            explanation='Reset on dispatcher startup: job was interrupted by a previous process exit',
+        )
+        if count:
+            logger.warning('Reset %d interrupted parse job(s) to FAILED on startup', count)

--- a/src/backend/apps/tasks/jobs.py
+++ b/src/backend/apps/tasks/jobs.py
@@ -167,8 +167,8 @@ class AAPParseDataTask(BaseTask):
             self.update_model(self.instance.pk, status=JobStatusChoices.FAILED, explanation=msg)
             return
 
-        data_parser = DataParser(sync_data.id)
         try:
+            data_parser = DataParser(sync_data.id)
             data_parser.parse()
         except DispatcherCancel:
             self.after_cancel_task()

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -6,11 +6,16 @@ from unittest.mock import PropertyMock
 
 import pytest
 import pytz
+import requests as requests_lib
 import time_machine
 from requests import Response
 
 from backend.apps.clusters.connector import ApiConnector
-from backend.apps.clusters.models import ClusterVersionChoices, Cluster, Organization, JobTemplate, ClusterSyncData
+from backend.apps.clusters.encryption import decrypt_value
+from backend.apps.clusters.models import (
+    ClusterVersionChoices, Cluster, Organization, JobTemplate,
+    ClusterSyncData, ClusterSyncStatus,
+)
 
 
 def get_response(**kwargs):
@@ -525,3 +530,258 @@ class TestConnector:
 
         assert 'Missing id or finished date time' in caplog.text
         assert not ClusterSyncData.objects.filter(cluster=cluster, data__id=100).exists()
+
+    # ------------------------------------------------------------------
+    # _reauthorize
+    # ------------------------------------------------------------------
+
+    def test_reauthorize_success(self, mocker, cluster):
+        """_reauthorize should update cluster tokens from a successful POST response."""
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps({
+            'access_token': 'new_access_token',
+            'refresh_token': 'new_refresh_token',
+        }).encode('utf-8')
+
+        mocker.patch('requests.post', return_value=mock_response)
+
+        connector = ApiConnector(cluster)
+        result = connector._reauthorize()
+
+        assert result is True
+        assert connector.access_token == 'new_access_token'
+        cluster.refresh_from_db()
+        assert decrypt_value(cluster.access_token) == 'new_access_token'
+        assert decrypt_value(cluster.refresh_token) == 'new_refresh_token'
+
+    def test_reauthorize_post_request_exception(self, mocker, cluster):
+        """_reauthorize should return False if POST raises a RequestException."""
+        mocker.patch('requests.post', side_effect=requests_lib.exceptions.RequestException('Timeout'))
+        connector = ApiConnector(cluster)
+        result = connector._reauthorize()
+        assert result is False
+
+    def test_reauthorize_non_ok_response(self, mocker, cluster, caplog):
+        """_reauthorize should return False if POST returns a non-OK status."""
+        mock_response = Response()
+        mock_response.status_code = 400
+        mock_response._content = b'Bad Request'
+
+        mocker.patch('requests.post', return_value=mock_response)
+
+        connector = ApiConnector(cluster)
+        with caplog.at_level(logging.ERROR, logger='automation_dashboard.clusters.connector'):
+            result = connector._reauthorize()
+
+        assert result is False
+        assert 'Token refresh POST request failed with status 400' in caplog.text
+
+    # ------------------------------------------------------------------
+    # _get_with_reauth
+    # ------------------------------------------------------------------
+
+    def test_get_with_reauth_retries_after_401(self, mocker, cluster):
+        """On 401, _get_with_reauth re-authorizes and retries; second response is returned."""
+        response_401 = Response()
+        response_401.status_code = 401
+        response_401._content = b'Unauthorized'
+
+        response_ok = get_response()  # 200 OK
+
+        mocker.patch('requests.get', side_effect=[response_401, response_ok])
+        mocker.patch(
+            'backend.apps.clusters.connector.ApiConnector._reauthorize',
+            return_value=True,
+        )
+
+        connector = ApiConnector(cluster)
+        result = connector._get_with_reauth(f"{cluster.base_url}/test")
+        assert result is not None
+        assert result.status_code == 200
+
+    def test_get_with_reauth_request_exception_returns_none(self, mocker, cluster, caplog):
+        """A plain RequestException (not ConnectionError) on first GET must return None."""
+        mocker.patch(
+            'requests.get',
+            side_effect=requests_lib.exceptions.Timeout('Timed out'),
+        )
+        connector = ApiConnector(cluster)
+        with caplog.at_level(logging.ERROR, logger='automation_dashboard.clusters.connector'):
+            result = connector._get_with_reauth(f"{cluster.base_url}/test")
+        assert result is None
+
+    def test_get_with_reauth_reraises_responses_connection_error(self, mocker, cluster):
+        """A ConnectionError from the `responses` library must be re-raised."""
+        error = requests_lib.exceptions.ConnectionError(
+            "Connection refused by Responses - the call doesn't match any registered mock."
+        )
+        mocker.patch('requests.get', side_effect=error)
+
+        connector = ApiConnector(cluster)
+        with pytest.raises(requests_lib.exceptions.ConnectionError) as exc_info:
+            connector._get_with_reauth(f"{cluster.base_url}/test")
+        assert 'Connection refused by Responses' in str(exc_info.value)
+
+    def test_get_with_reauth_second_request_exception_returns_none(self, mocker, cluster, caplog):
+        """RequestException on the *retry* GET (after 401) must return None."""
+        response_401 = Response()
+        response_401.status_code = 401
+        response_401._content = b'Unauthorized'
+
+        mocker.patch(
+            'requests.get',
+            side_effect=[response_401, requests_lib.exceptions.Timeout('Timed out again')],
+        )
+        mocker.patch(
+            'backend.apps.clusters.connector.ApiConnector._reauthorize',
+            return_value=True,
+        )
+
+        connector = ApiConnector(cluster)
+        result = connector._get_with_reauth(f"{cluster.base_url}/test")
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # execute_get_one / execute_get
+    # ------------------------------------------------------------------
+
+    def test_execute_get_one_returns_none_when_no_response(self, mocker, cluster):
+        """execute_get_one should return None when _get_with_reauth returns None."""
+        mocker.patch(
+            'backend.apps.clusters.connector.ApiConnector._get_with_reauth',
+            return_value=None,
+        )
+        connector = ApiConnector(cluster)
+        result = connector.execute_get_one(f"{cluster.base_url}/test")
+        assert result is None
+
+    def test_execute_get_none_response_yields_empty_list(self, mocker, cluster):
+        """execute_get should yield an empty list when execute_get_one returns None."""
+        mocker.patch(
+            'backend.apps.clusters.connector.ApiConnector.execute_get_one',
+            return_value=None,
+        )
+        connector = ApiConnector(cluster)
+        results = list(connector.execute_get(endpoint='/api/v2/test/'))
+        assert results == [[]]
+
+    # ------------------------------------------------------------------
+    # job_host_summaries
+    # ------------------------------------------------------------------
+
+    def test_job_host_summaries(self, mocker, cluster):
+        """job_host_summaries should yield all summaries returned by the API."""
+        summaries = [
+            {'id': 1, 'host_name': 'Host A'},
+            {'id': 2, 'host_name': 'Host B'},
+        ]
+        mock = mocker.patch('backend.apps.clusters.connector.ApiConnector.execute_get')
+        mock.side_effect = [[iter(summaries)]]
+        connector = ApiConnector(cluster)
+        result = list(connector.job_host_summaries(42))
+        assert result == summaries
+
+    # ------------------------------------------------------------------
+    # detect_aap_version  (additional scenarios)
+    # ------------------------------------------------------------------
+
+    def test_detect_aap_version_26(self, mocker, cluster):
+        """detect_aap_version should return AAP26 when the gateway returns version 2.6."""
+        def mocked_requests_get(*args, **kwargs):
+            headers = {
+                'Content-Type': 'application/json',
+                'X-Api-Product-Name': 'Red Hat Ansible Automation Platform',
+            }
+            return get_response(**{'headers': headers, 'data': {'version': '2.6'}})
+
+        connector = ApiConnector(cluster)
+        mocker.patch('requests.get', new=mocked_requests_get)
+        assert connector.detect_aap_version() == ClusterVersionChoices.AAP26
+
+    def test_detect_aap_version_unknown_version_raises(self, mocker, cluster):
+        """detect_aap_version should raise when the gateway responds with an unknown version."""
+        def mocked_requests_get(*args, **kwargs):
+            headers = {
+                'Content-Type': 'application/json',
+                'X-Api-Product-Name': 'Red Hat Ansible Automation Platform',
+            }
+            return get_response(**{'headers': headers, 'data': {'version': '9.9'}})
+
+        connector = ApiConnector(cluster)
+        mocker.patch('requests.get', new=mocked_requests_get)
+        with pytest.raises(Exception) as exc_info:
+            connector.detect_aap_version()
+        assert 'Not valid version' in str(exc_info.value)
+
+    def test_detect_aap_version_both_pings_fail_raises(self, mocker, cluster):
+        """detect_aap_version should raise when both gateway and v2 pings return None."""
+        mocker.patch(
+            'backend.apps.clusters.connector.ApiConnector.ping',
+            return_value=None,
+        )
+        connector = ApiConnector(cluster)
+        with pytest.raises(Exception) as exc_info:
+            connector.detect_aap_version()
+        assert 'Not valid version' in str(exc_info.value)
+
+    # ------------------------------------------------------------------
+    # __init__ – edge-case since / managed logic
+    # ------------------------------------------------------------------
+
+    def test_init_managed_uses_provided_since(self, cluster):
+        """In managed mode the connector must use the explicitly provided `since` value."""
+        since = datetime(2025, 5, 1, tzinfo=pytz.UTC)
+        connector = ApiConnector(cluster, since=since, managed=True)
+        assert connector.since == since
+        assert connector.managed is True
+
+    @pytest.mark.django_db(transaction=True)
+    def test_init_uses_last_job_finished_date_from_sync_status(self, cluster):
+        """Without an explicit `since`, the connector should fall back to the last sync date."""
+        last_date = datetime(2025, 3, 15, 12, 0, 0, tzinfo=pytz.UTC)
+        ClusterSyncStatus.objects.create(cluster=cluster, last_job_finished_date=last_date)
+        connector = ApiConnector(cluster)
+        assert connector.since == last_date
+
+    @time_machine.travel(datetime(2025, 10, 21, 22, 1, 45, tzinfo=pytz.UTC))
+    def test_since_invalid_iso_date_falls_back_to_timedelta(self, settings, cluster):
+        """An unparseable INITIAL_SYNC_SINCE must fall back to now() – INITIAL_SYNC_DAYS."""
+        settings.INITIAL_SYNC_SINCE = 'not-a-valid-date'
+        settings.INITIAL_SYNC_DAYS = 7
+        connector = ApiConnector(cluster)
+        assert str(connector.since) == '2025-10-14 00:00:00+00:00'
+
+    # ------------------------------------------------------------------
+    # sync_jobs – invalid finished format
+    # ------------------------------------------------------------------
+
+    def test_sync_jobs_invalid_finished_format_raises(self, mocker, cluster):
+        """sync_jobs must raise TypeError when the `finished` field is not ISO-8601."""
+        job = {
+            'id': 77,
+            'finished': 'not-a-date',
+            'started': '2025-01-16T20:00:00.000000Z',
+            'status': 'successful',
+        }
+        connector = ApiConnector(cluster)
+        mocker.patch.object(type(connector), 'jobs', new_callable=PropertyMock, return_value=[job])
+
+        with pytest.raises(TypeError):
+            connector.sync_jobs()
+
+    # ------------------------------------------------------------------
+    # ping – request exception
+    # ------------------------------------------------------------------
+
+    def test_ping_request_exception_returns_none(self, mocker, cluster, caplog):
+        """ping() must return None and log the exception on a RequestException."""
+        mocker.patch(
+            'requests.get',
+            side_effect=requests_lib.exceptions.Timeout('Connection timed out'),
+        )
+        connector = ApiConnector(cluster)
+        with caplog.at_level(logging.ERROR, logger='automation_dashboard.clusters.connector'):
+            result = connector.ping('/api/v2/ping/')
+        assert result is None
+

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -1,6 +1,8 @@
 import json
+import logging
 from datetime import datetime
 from http import HTTPStatus
+from unittest.mock import PropertyMock
 
 import pytest
 import pytz
@@ -493,3 +495,33 @@ class TestConnector:
         connector = ApiConnector(cluster, since=since, until=until)
         assert str(connector.since) == '2025-10-01 00:00:00+00:00'
         assert str(connector.until) == '2025-10-31 23:59:59.999999+00:00'
+
+    def test_sync_jobs_null_started_is_ingested_and_logged(self, mocker, cluster, caplog):
+        """A job with started=null must be stored in ClusterSyncData and produce an info log."""
+        job = {
+            "id": 99,
+            "finished": "2025-01-16T20:44:21.000000Z",
+            "started": None,
+            "status": "failed",
+        }
+        connector = ApiConnector(cluster)
+        mocker.patch.object(type(connector), 'jobs', new_callable=PropertyMock, return_value=[job])
+        mocker.patch.object(connector, 'job_host_summaries', return_value=iter([]))
+
+        with caplog.at_level(logging.INFO, logger='automation_dashboard.clusters.connector'):
+            connector.sync_jobs()
+
+        assert 'has null started time' in caplog.text
+        assert ClusterSyncData.objects.filter(cluster=cluster, data__id=99).exists()
+
+    def test_sync_jobs_missing_finished_is_skipped(self, mocker, cluster, caplog):
+        """A job without a finished timestamp must be skipped and not stored."""
+        job = {"id": 100, "finished": None, "started": "2025-01-16T20:00:00.000000Z", "status": "running"}
+        connector = ApiConnector(cluster)
+        mocker.patch.object(type(connector), 'jobs', new_callable=PropertyMock, return_value=[job])
+
+        with caplog.at_level(logging.WARNING, logger='automation_dashboard.clusters.connector'):
+            connector.sync_jobs()
+
+        assert 'Missing id or finished date time' in caplog.text
+        assert not ClusterSyncData.objects.filter(cluster=cluster, data__id=100).exists()

--- a/src/backend/tests/unit/test_jobs.py
+++ b/src/backend/tests/unit/test_jobs.py
@@ -95,6 +95,21 @@ class TestJobs:
 
     @patch("backend.apps.tasks.jobs.DataParser")
     @patch("backend.apps.tasks.jobs.AAPParseDataTask.update_model")
+    def test_run_task_data_parser_init_exception_sets_failed(self, mock_update_model, mock_data_parser):
+        """DataParser.__init__ raising must mark the SyncJob FAILED, not leave it stuck in RUNNING."""
+        task = AAPParseDataTask()
+        sync_data = MagicMock()
+        sync_data.id = 42
+        instance = MagicMock()
+        instance.cluster_sync_data = sync_data
+        instance.pk = 1
+        task.instance = instance
+        mock_data_parser.side_effect = Exception("pydantic validation error: started is null")
+        task.run_task()
+        mock_update_model.assert_called_with(instance.pk, status=JobStatusChoices.FAILED, explanation="Failed to parse AAP sync data: 42")
+
+    @patch("backend.apps.tasks.jobs.DataParser")
+    @patch("backend.apps.tasks.jobs.AAPParseDataTask.update_model")
     def test_run_task_successful(self, mock_update_model, mock_data_parser):
         task = AAPParseDataTask()
         sync_data = MagicMock()

--- a/src/backend/tests/unit/test_manage.py
+++ b/src/backend/tests/unit/test_manage.py
@@ -3,6 +3,58 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+from backend.apps.clusters.models import JobStatusChoices
+from backend.apps.dispatch.management.commands.run_dispatcher import Command
+from backend.apps.scheduler.models import SyncJob, JobTypeChoices
+
+
+@pytest.mark.django_db
+class TestResetInterruptedJobs:
+
+    def test_resets_stuck_parse_jobs_to_failed(self, cluster):
+        running = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.RUNNING, launch_type='auto')
+        pending = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.PENDING, launch_type='auto')
+        waiting = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.WAITING, launch_type='auto')
+
+        Command()._reset_interrupted_jobs()
+
+        for job in [running, pending, waiting]:
+            job.refresh_from_db()
+            assert job.status == JobStatusChoices.FAILED
+
+    def test_does_not_reset_completed_parse_jobs(self, cluster):
+        failed = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.FAILED, launch_type='auto')
+        successful = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.SUCCESSFUL, launch_type='auto')
+
+        Command()._reset_interrupted_jobs()
+
+        failed.refresh_from_db()
+        successful.refresh_from_db()
+        assert failed.status == JobStatusChoices.FAILED
+        assert successful.status == JobStatusChoices.SUCCESSFUL
+
+    def test_does_not_reset_sync_jobs(self, cluster):
+        """Only PARSE_JOB_DATA jobs should be reset; sync jobs in RUNNING state are left alone."""
+        sync_running = SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.SYNC_JOBS, status=JobStatusChoices.RUNNING, launch_type='auto')
+
+        Command()._reset_interrupted_jobs()
+
+        sync_running.refresh_from_db()
+        assert sync_running.status == JobStatusChoices.RUNNING
+
+    def test_logs_warning_with_count_when_jobs_reset(self, cluster, caplog):
+        SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.RUNNING, launch_type='auto')
+        SyncJob.objects.create(cluster=cluster, type=JobTypeChoices.PARSE_JOB_DATA, status=JobStatusChoices.PENDING, launch_type='auto')
+
+        Command()._reset_interrupted_jobs()
+
+        assert 'Reset 2 interrupted parse job(s) to FAILED on startup' in caplog.text
+
+    def test_no_log_when_no_stuck_jobs(self, cluster, caplog):
+        Command()._reset_interrupted_jobs()
+
+        assert 'Reset' not in caplog.text
+
 
 class TestUpdatePassword(TestCase):
     @pytest.fixture(autouse=True)

--- a/src/backend/tests/unit/test_manage.py
+++ b/src/backend/tests/unit/test_manage.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -54,6 +55,22 @@ class TestResetInterruptedJobs:
         Command()._reset_interrupted_jobs()
 
         assert 'Reset' not in caplog.text
+
+    def test_handle_calls_reset_interrupted_jobs_before_service_start(self, cluster):
+        """handle() must call _reset_interrupted_jobs() even when the dispatcher
+        itself is mocked out — this covers the call-site line in handle()."""
+        with (
+            mock.patch('backend.apps.dispatch.management.commands.run_dispatcher.get_dispatcherd_config'),
+            mock.patch('backend.apps.dispatch.management.commands.run_dispatcher.dispatcher_setup'),
+            mock.patch('backend.apps.dispatch.management.commands.run_dispatcher.DispatcherMetricsServer') as mock_metrics,
+            mock.patch('backend.apps.dispatch.management.commands.run_dispatcher.run_service'),
+        ):
+            mock_metrics.return_value.start.return_value = None
+            cmd = Command()
+            with mock.patch.object(cmd, '_reset_interrupted_jobs') as mock_reset:
+                cmd.handle(test=None, reload=None, cancel=None, running=None)
+
+        mock_reset.assert_called_once()
 
 
 class TestUpdatePassword(TestCase):


### PR DESCRIPTION
## Summary

- `DataParser()` construction was outside the try/except in `AAPParseDataTask.run_task()`, causing any exception during parser initialisation (e.g. a Pydantic `ValidationError`) to escape to dispatcherd without ever marking the `SyncJob` as `FAILED`. The job was left permanently in `RUNNING` state.
- AAP 2.4 (and occasionally 2.6) returns `"started": null` for jobs that were queued but never executed (blocked waiting for a dependency, e.g. `"job_explanation": "waiting for projectupdate-149333 to finish"`). On deployed versions where `ExternalJobSchema.started` was typed as `datetime` (non-optional), this produced a `ValidationError` on every such job, triggering the stuck-RUNNING accumulation above.
- `logger.error()` was used inside four `except` blocks in `connector.py` instead of `logger.exception()`, suppressing tracebacks.

## Investigation

### The cascade

1. A job with `"started": null` is fetched from AAP and stored in `ClusterSyncData`.
2. `ClusterSyncData.save()` creates a `SyncJob` with `status=NEW`.
3. `automation_dashboard_job_parser_data_scheduler` picks it up, transitions it to `PENDING` via `signal_start()`.
4. Dispatcherd picks it up and transitions it to `RUNNING` via `BaseTask.transition_status()`.
5. `AAPParseDataTask.run_task()` calls `DataParser(sync_data.id)`, which calls `ExternalJobSchema(**self.model.data)` inside `DataParser.__init__`.
6. Pydantic raises `ValidationError: started — Input should be a valid datetime [input_value=None]`.
7. The exception escapes `run_task()` → `BaseTask.run()` → dispatcherd's `perform_work()`, which logs `Worker failed to run task` but **never calls `update_model(..., status=FAILED)`**.
8. The `SyncJob` is permanently stuck in `RUNNING`.
9. Repeated syncs accumulate more stuck `RUNNING` jobs.
10. Once the count of `PENDING + WAITING + RUNNING` parse jobs reaches 30, `ClusterSyncData.cache_timeout_blocked` returns `True` for every record on that cluster.
11. `automation_dashboard_job_parser_data_scheduler` skips all `NEW` jobs → total ingestion paralysis, log flooded with:

```
ERROR  models  Parse job data https://... - <id> could not be started because there are more than 30 other jobs from that template waiting to run
WARNING system  Cache timeout is in the future, bypassing job parser for job <id>
```

### Schema note

`ExternalJobSchema.started` is already typed as `datetime | None = None` in the current repo, so the Pydantic error will not occur on a fresh deployment. The critical latent bug — `DataParser()` construction outside the try/except — remained and would cause identical deadlocks for any future parsing exception.

## Changes

**`src/backend/apps/tasks/jobs.py`** — moved `DataParser(sync_data.id)` inside the existing try/except so that any exception raised during parser construction (not just during `parse()`) correctly sets `SyncJob.status=FAILED` and unblocks the queue.

**`src/backend/apps/clusters/connector.py`** — replaced four `logger.error()` calls inside `except` blocks with `logger.exception()` to include tracebacks; added an info-level log when a job with `started=null` is encountered.

**`src/backend/apps/dispatch/management/commands/run_dispatcher.py`** — added `_reset_interrupted_jobs()`, called on dispatcher startup before `run_service()`. Any parse `SyncJob` left in `RUNNING`, `PENDING`, or `WAITING` state from a previous process exit is reset to `FAILED`. This clears the deadlock automatically on redeploy without requiring manual database intervention.

```
WARNING Reset N interrupted parse job(s) to FAILED on startup
```

## Test plan

- [ ] Verify a job payload with `"started": null` is ingested without error and stored with `started=None` on the `Job` model
- [ ] Verify that when `DataParser.__init__` raises (e.g. inject a bad payload), the `SyncJob` transitions to `FAILED` and does not accumulate in `RUNNING`
- [ ] Verify that on dispatcher restart, any stuck RUNNING/PENDING/WAITING parse jobs are reset to `FAILED` and the warning is logged
- [ ] Confirm `cache_timeout_blocked` does not trigger after the above scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches job lifecycle/dispatcher startup behavior by force-failing stuck parse jobs and broadening exception coverage, which could affect operational recovery paths if the filtering is wrong. Changes are localized and backed by new unit tests, lowering overall risk.
> 
> **Overview**
> Prevents `PARSE_JOB_DATA` jobs from getting stuck in `RUNNING` by wrapping `DataParser(sync_data.id)` construction inside the existing `try/except` in `AAPParseDataTask.run_task()`, ensuring init-time failures also transition the `SyncJob` to `FAILED`.
> 
> Adds a dispatcher startup safeguard (`Command._reset_interrupted_jobs`) that marks any parse jobs left in `RUNNING`/`PENDING`/`WAITING` as `FAILED` with an explanation, and logs a warning count.
> 
> Improves cluster connector robustness by switching request-failure logging to `logger.exception()` (preserving tracebacks) and explicitly logging/ingesting AAP jobs with `started=null`; expands unit coverage around reauth/retry behavior and these edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c59863f254a55f0b77b8f3b49b56b3b08e02799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatcher now automatically resets interrupted parse jobs on startup, preventing stuck jobs from blocking operations.
  * Task failures during parsing initialization now mark jobs as failed instead of leaving them running.

* **Improvements**
  * Exception logging for external calls now includes stack traces for better diagnostics.
  * Job ingestion handles edge cases: null start times proceed with an informational log; jobs missing required fields are skipped with warnings.

* **Tests**
  * Added unit tests covering the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->