### PR TITLE
Add UI setup wizard, DB-direct sync, cluster management, and compose dev stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**automation-reports** is a monorepo dashboard for Ansible Automation Platform (AAP). It syncs job data from one or more AAP clusters via OAuth2, stores it in PostgreSQL, and serves analytics/reporting through a REST API and React frontend.
+
+Stack: Django 5 + DRF (backend), React 19 + TypeScript + PatternFly (frontend), dispatcherd (background tasks), PostgreSQL, Redis.
+
+---
+
+## Environment Setup
+
+```bash
+# Python
+python3.12 -m venv .venv
+cp .env.example .env          # fill in DB credentials and secrets
+source .env.sh                # loads .env + activates venv + sets PYTHONPATH=$PWD/src
+
+# Node
+nvm use v22.21.1
+cd src/frontend && npm install
+```
+
+Local Django overrides go in `src/backend/django_config/local_settings.py` (copy from `local_settings.example.py`).
+
+Cluster connection config (OAuth2 tokens, addresses, sync schedules) goes in `clusters.yaml` (copy from `clusters.example.yaml`).
+
+---
+
+## Development Commands
+
+### Backend
+
+```bash
+# From repo root, after `source .env.sh`
+cd src/backend
+python manage.py migrate
+python manage.py setclusters clusters.yaml   # load cluster config
+python manage.py getclusters                 # export cluster config (encrypted)
+python manage.py runserver                   # API on :8000
+python manage.py run_dispatcher              # background task processor (separate terminal)
+python manage.py syncdata --since=DATE --until=DATE  # manual sync
+```
+
+### Frontend
+
+```bash
+cd src/frontend
+npm run start:dev    # Vite dev server on :9000 (proxies API to :8000)
+npm run build        # tsc check + Vite production build
+npm run lint         # ESLint
+npm run format       # Prettier check
+npm run type-check   # TypeScript only
+npm run ci-checks    # type-check + lint + test:coverage (canonical CI gate)
+```
+
+### Docker (for DB + Redis only in dev)
+
+```bash
+docker compose -f compose/compose.yml up db redis
+```
+
+### Dependency Management
+
+```bash
+make sync-requirements    # recompile and pin requirements-build.txt via pip-compile
+make requirements-check   # verify requirements-build.txt is in sync (used in CI)
+```
+
+---
+
+## Testing
+
+### Backend
+
+```bash
+# From repo root, after `source .env.sh`
+pytest                          # all tests (creates a fresh DB each run via --create-db)
+pytest tests/path/to/test.py    # single file
+pytest --cov=backend            # with coverage
+```
+
+Config in `pyproject.toml` (`[tool.pytest.ini_options]`). Test settings: `src/backend/tests/settings_for_test.py`. Migrations are disabled in tests (`--nomigrations`). Pre-recorded AAP HTTP responses for mocking live in `src/backend/tests/mock_aap/`.
+
+### Frontend (Playwright E2E)
+
+```bash
+npx playwright install chromium   # first time
+npx playwright test               # headless
+npx playwright test --headed      # show browser
+```
+
+Tests live in `tests/playwright/specs/`. Config: `playwright.config.ts`. Requires dev server running on `:9000`. On CI, workers=1 with 2 retries; locally fully parallel.
+
+---
+
+## Architecture
+
+### Backend (`src/backend/`)
+
+Django apps in `src/backend/apps/`:
+
+| App | Purpose |
+|-----|---------|
+| `clusters` | Core: AAP cluster models, data sync connector, job/event parsing |
+| `aap_auth` | OAuth2 authentication against AAP |
+| `dispatch` | dispatcherd integration for background tasks |
+| `scheduler` | RFC 5545 rrule-based sync scheduling |
+| `tasks` | Background task definitions |
+| `analytics` | Prometheus metrics collectors and aggregation pipeline |
+| `common` | Shared utilities and base models |
+| `users` | User management |
+
+Key files:
+- `apps/clusters/connector.py` (~17k lines) — AAP API client: OAuth2, data fetch, credential management
+- `apps/clusters/parser.py` (~14k lines) — job event parsing and metrics calculation
+- `apps/clusters/models.py` — core domain models: `Cluster`, `Job`, `JobTemplate`, `Organization`, `SubscriptionCost` (singleton via django-solo)
+- `analytics/metrics.py` — Prometheus gauge definitions (jobs total, by status, by type); exposed at `/api/v1/metrics/`
+- `django_config/settings.py` — split settings via `split-settings` library
+- `api/v1/` — DRF viewsets and routers; OpenAPI schema at `/api/v1/schema/`
+
+Settings split: base settings + optional `local_settings.py`. Key env-configurable vars: `JOB_EVENT_WORKERS` (default 4), `SCHEDULE_MAX_DATA_PARSE_JOBS` (default 30).
+
+Request tracing: `django_guid` middleware injects a request ID into every response.
+
+### Frontend (`src/frontend/app/`)
+
+Built with **Vite** (not webpack). PatternFly 6 + Victory charts.
+
+| Directory | Purpose |
+|-----------|---------|
+| `AppLayout/` | Shell layout components |
+| `Components/` | Reusable UI components (tables, filters, date picker, etc.) |
+| `Dashboard/` | Main dashboard page with bar charts and totals |
+| `Store/` | Zustand stores: `authStore`, `filterStore`, `filterOptionsStore`, `commonStore` |
+| `Services/` | API calls via `RestService.ts` |
+| `client/` | Axios instance + request interceptors |
+| `Types/` | TypeScript interfaces |
+| `Utils/` | Shared helpers |
+
+Routing via React Router 7. Auth flow: `/login` → OAuth2 to AAP → `/auth-callback` → token stored in `authStore`.
+
+### Task Processing
+
+Background tasks use **dispatcherd** (replaces Celery/dramatiq). The dispatcher process (`python manage.py run_dispatcher`) must be running for sync jobs to execute. Sync jobs are enqueued by the scheduler based on rrule schedules defined in `clusters.yaml`.
+
+### Data Flow
+
+```
+AAP Cluster API
+  └─► connector.py (OAuth2 fetch)
+      └─► parser.py (event/metrics parsing)
+          └─► PostgreSQL models (clusters app)
+              └─► DRF API (api/v1/)
+                  └─► React frontend
+```
+
+### Container Layout
+
+The production image (multi-stage `Dockerfile.backend`) runs nginx on port **8053**, serving the Vite-built frontend as static files and proxying `/api/` to uvicorn (ASGI). Development uses separate :8000 (Django) and :9000 (Vite) processes.
+
+---
+
+## Key Conventions
+
+- **Python path**: `PYTHONPATH=$PWD/src` (set by `.env.sh`); import as `from backend.apps...` or `from apps...`
+- **Prettier**: single quotes, 120 char print width
+- **ESLint**: TypeScript strict, `sort-imports` enforced, PropTypes disabled (use TS types)
+- **API versioning**: all endpoints under `/api/v1/`; pagination default 100 items
+- **Cluster secrets** (tokens, credentials) are encrypted at rest; use `getclusters` management command to export with encryption
+- **Pinned deps**: `requirements-build.txt` is the pinned lockfile; edit `requirements.txt` then run `make sync-requirements` to regenerate it

--- a/compose/compose.dev-override.yml
+++ b/compose/compose.dev-override.yml
@@ -1,0 +1,58 @@
+# Local development override — swaps Red Hat registry images for public equivalents.
+# Usage: docker compose -f compose/compose.yml -f compose/compose.dev-override.yml up -d --build
+---
+services:
+  db:
+    image: postgres:15
+    ports: []
+    environment:
+      # postgres:15 uses POSTGRES_* not POSTGRESQL_*
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    volumes:
+      - type: bind
+        source: ./init-db-public.sh
+        target: /docker-entrypoint-initdb.d/10-grant-createdb.sh
+        read_only: true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.backend
+    volumes:
+      - type: bind
+        source: ../src/backend
+        target: /code/src/backend
+        read_only: true
+      - type: bind
+        source: ./dev_settings/SECRET_KEY
+        target: /etc/dashboard/SECRET_KEY
+        read_only: true
+      - type: bind
+        source: ./dev_settings/DATABASE_KEY
+        target: /etc/dashboard/DATABASE_KEY
+        read_only: true
+      - type: bind
+        source: ./dev_settings/AAP_AUTH_PROVIDER_CLIENT_SECRET
+        target: /etc/dashboard/AAP_AUTH_PROVIDER_CLIENT_SECRET
+        read_only: true
+      - type: bind
+        source: ./dev_settings/conf.d
+        target: /etc/dashboard/conf.d
+        read_only: true
+
+  redis:
+    image: redis:6
+    ports: []
+    user: ""
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -4,10 +4,9 @@ services:
   db:
     image: registry.redhat.io/rhel8/postgresql-15:latest
     env_file:
-      - path: "./.env"
+      - path: "../.env"
         required: true
     environment:
-      # - POSTGRESQL_ADMIN_PASSWORD=${DB_PASSWORD}
       - POSTGRESQL_USER=${DB_USER}
       - POSTGRESQL_PASSWORD=${DB_PASSWORD}
       - POSTGRESQL_DATABASE=${DB_NAME}
@@ -23,7 +22,7 @@ services:
          source: postgres-data
          target: /var/lib/psql/data
        - type: bind
-         source: ./compose/init-db.sh
+         source: ./init-db.sh
          target: /usr/share/container-scripts/postgresql/start/10-grant-createdb.sh
          read_only: true
          bind:
@@ -36,7 +35,7 @@ services:
       - "6379:6379"
     volumes:
       - type: bind
-        source: ./compose/redis.conf
+        source: ./redis.conf
         target: /etc/redis.conf
         read_only: true
         bind:
@@ -54,11 +53,10 @@ services:
       redis:
         condition: service_healthy
     build:
-      context: ./
+      context: ../
       dockerfile: docker/Dockerfile.backend
-    # command: /venv/bin/python manage.py -h
     env_file:
-      - path: "./.env"
+      - path: "../.env"
         required: true
     environment:
       - DB_HOST=db
@@ -70,13 +68,6 @@ services:
     ports:
       - "8083:8053"  # nginx
       # - "8000:8000"  # django-api
-
-  # frontend:
-  #   build:
-  #     context: ./
-  #     dockerfile: docker/Dockerfile.backend
-  #   ports:
-  #     - "9000:8080"
 
 volumes:
   postgres-data:

--- a/compose/dev_settings/DATABASE_KEY
+++ b/compose/dev_settings/DATABASE_KEY
@@ -1,0 +1,1 @@
+dev-database-key-insecure-change-for-production

--- a/compose/dev_settings/SECRET_KEY
+++ b/compose/dev_settings/SECRET_KEY
@@ -1,0 +1,1 @@
+dev-secret-key-insecure-change-for-production

--- a/compose/dev_settings/conf.d/django_dev.py
+++ b/compose/dev_settings/conf.d/django_dev.py
@@ -1,0 +1,37 @@
+import os
+
+with open('/etc/dashboard/SECRET_KEY') as f:
+    SECRET_KEY = f.read().strip()
+
+with open('/etc/dashboard/DATABASE_KEY') as f:
+    DATABASE_KEY = f.read().strip()
+
+# AAP auth not configured yet — setup wizard handles this
+AAP_AUTH_PROVIDER_CLIENT_SECRET = ''
+AAP_AUTH_PROVIDER = {
+    'name': 'Ansible Automation Platform',
+    'protocol': 'https',
+    'url': 'http://localhost',
+    'user_data_endpoint': 'http://localhost',
+    'check_ssl': False,
+    'client_id': '',
+    'client_secret': '',
+}
+
+ALLOWED_HOSTS = ['*']
+DEBUG = True
+
+# Enable local-account login for the compose dev environment.
+# Never set this in production.
+ALLOW_DEV_LOGIN = True
+
+# Redis via TCP (not unix socket as in the Ansible installer)
+BROKER_URL = 'redis://redis:6379/0'
+
+SHOW_URLLIB3_INSECURE_REQUEST_WARNING = False
+INITIAL_SYNC_DAYS = 1
+WEASYPRINT_BASEURL = '/code/src/backend/templates'
+JWT_ACCESS_TOKEN_LIFETIME_SECONDS = 3600
+JWT_REFRESH_TOKEN_LIFETIME_SECONDS = 86400
+
+CORS_ALLOWED_ORIGINS = ['http://localhost:8083', 'http://localhost:9000']

--- a/compose/dev_settings/conf.d/postgres.py
+++ b/compose/dev_settings/conf.d/postgres.py
@@ -1,0 +1,12 @@
+import os
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.environ.get('DB_NAME', 'aapdashboard'),
+        'USER': os.environ.get('DB_USER', 'aapdashboard'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+        'HOST': os.environ.get('DB_HOST', 'db'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+    }
+}

--- a/compose/init-db-public.sh
+++ b/compose/init-db-public.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Grants CREATEDB to the app user — for postgres:15 (public image).
+# Runs automatically via /docker-entrypoint-initdb.d/ on first start.
+set -e
+psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<-EOSQL
+    ALTER USER "$POSTGRES_USER" CREATEDB;
+EOSQL

--- a/docker/launch_automation_dashboard.sh
+++ b/docker/launch_automation_dashboard.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 # Script is started via dumb-init
 
-##!/usr/bin/env bash
-#if [ `id -u` -ge 500 ]; then
-#    echo "awx:x:`id -u`:`id -g`:,,,:/var/lib/awx:/bin/bash" >> /tmp/passwd
-#    cat /tmp/passwd > /etc/passwd
-#    rm /tmp/passwd
-#fi
-
 nginx -g 'daemon off;' &
 /venv/bin/python manage.py runserver 0.0.0.0:8000 &
+/venv/bin/python manage.py run_dispatcher &
 exec sleep inf

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -110,6 +110,7 @@ http {
         # location /static/ {
         location / {
             alias /opt/app-root/src/;
+            try_files $uri $uri/ /index.html;
         }
 
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,5 @@ testpaths = [
   ]
 
 filterwarnings = [
-  "ignore::django.utils.deprecation.RemovedInDjango60Warning",
-  "ignore::django.utils.deprecation.RemovedInDjango61Warning",
+  "ignore::DeprecationWarning",
 ]

--- a/src/backend/api/v1/aap_auth/urls.py
+++ b/src/backend/api/v1/aap_auth/urls.py
@@ -4,7 +4,8 @@ from backend.api.v1.aap_auth.views import (
     AAPSettingsView,
     AAPTokenView,
     AAPRefreshTokenView,
-    AAPLogoutView
+    AAPLogoutView,
+    DevLoginView,
 )
 
 urlpatterns = [
@@ -12,4 +13,5 @@ urlpatterns = [
     path("token/", AAPTokenView.as_view(), name="AAPTokenView"),
     path("refresh_token/", AAPRefreshTokenView.as_view(), name="AAPRefreshTokenView"),
     path("logout/", AAPLogoutView.as_view(), name="LogoutView"),
+    path("dev_login/", DevLoginView.as_view(), name="DevLoginView"),
 ]

--- a/src/backend/api/v1/aap_auth/views.py
+++ b/src/backend/api/v1/aap_auth/views.py
@@ -68,7 +68,15 @@ class AAPSettingsView(BaseAAPView):
     serializer_class = AAPAuthSettingsSerializer
 
     def get(self, request: Request) -> Response:
-        aap_auth = AAPAuth()
+        try:
+            aap_auth = AAPAuth()
+        except Exception:
+            # AAP auth provider not configured — return empty settings so the
+            # frontend can detect this and show a local login fallback.
+            return Response(
+                data={'name': '', 'url': '', 'client_id': '', 'scope': '', 'approval_prompt': '', 'response_type': ''},
+                status=status.HTTP_200_OK,
+            )
         return Response(
             data=self.serializer_class(aap_auth.ui_data()).data,
             status=status.HTTP_200_OK
@@ -108,6 +116,38 @@ class AAPRefreshTokenView(BaseAAPView):
             tokens = aap_auth.refresh_token(refresh_token=refresh_token)
         except Exception as e:
             return Response(data={"message": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        csrf.get_token(request)
+        return make_response(tokens)
+
+
+class DevLoginView(BaseAAPView):
+    """Local-account bypass for development (ALLOW_DEV_LOGIN=True only)."""
+
+    def post(self, request: Request) -> Response:
+        if not getattr(settings, 'ALLOW_DEV_LOGIN', False):
+            return Response(
+                {'error': 'Local login is not enabled on this server.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        from django.contrib.auth import authenticate as django_authenticate
+        from backend.apps.aap_auth.jwt_token import JWTToken
+        from backend.apps.aap_auth.schema import AAPToken
+
+        username = request.data.get('username', '')
+        password = request.data.get('password', '')
+        django_request = getattr(request, '_request', request)
+        user = django_authenticate(django_request, username=username, password=password)
+        if not user:
+            return Response({'error': 'Invalid credentials'}, status=status.HTTP_401_UNAUTHORIZED)
+
+        dummy_aap_token = AAPToken(
+            access_token='dev',
+            refresh_token='dev',
+            expires_in=86400,
+            token_type='Bearer',
+        )
+        tokens = JWTToken().acquire_token_pair(user=user, aap_token=dummy_aap_token)
         csrf.get_token(request)
         return make_response(tokens)
 

--- a/src/backend/api/v1/clusters/serializers.py
+++ b/src/backend/api/v1/clusters/serializers.py
@@ -1,0 +1,65 @@
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+
+from backend.apps.clusters.models import Cluster, ClusterVersionChoices
+
+
+class ClusterReadSerializer(serializers.ModelSerializer):
+    last_synced = serializers.SerializerMethodField()
+    has_access_token = serializers.SerializerMethodField()
+    has_refresh_token = serializers.SerializerMethodField()
+    has_db_password = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Cluster
+        fields = [
+            'id',
+            'protocol',
+            'address',
+            'port',
+            'aap_version',
+            'verify_ssl',
+            'client_id',
+            'last_synced',
+            'has_access_token',
+            'has_refresh_token',
+            'sync_mode',
+            'db_host',
+            'db_port',
+            'db_name',
+            'db_user',
+            'has_db_password',
+        ]
+
+    def get_last_synced(self, obj):
+        try:
+            return obj.status.last_job_finished_date.isoformat()
+        except ObjectDoesNotExist:
+            return None
+
+    def get_has_access_token(self, obj):
+        return bool(obj.access_token)
+
+    def get_has_refresh_token(self, obj):
+        return bool(obj.refresh_token)
+
+    def get_has_db_password(self, obj):
+        return bool(obj.db_password)
+
+
+class ClusterWriteSerializer(serializers.Serializer):
+    protocol = serializers.ChoiceField(choices=['http', 'https'])
+    address = serializers.CharField(max_length=255)
+    port = serializers.IntegerField(default=443, min_value=1, max_value=65535)
+    aap_version = serializers.ChoiceField(choices=ClusterVersionChoices.values)
+    verify_ssl = serializers.BooleanField(default=True)
+    client_id = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    client_secret = serializers.CharField(required=False, allow_blank=True, default='')
+    access_token = serializers.CharField(required=False, allow_blank=True, default='')
+    refresh_token = serializers.CharField(required=False, allow_blank=True, default='')
+    sync_mode = serializers.ChoiceField(choices=['api', 'database'], default='api')
+    db_host = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    db_port = serializers.IntegerField(default=5432, required=False)
+    db_name = serializers.CharField(max_length=255, required=False, allow_blank=True, default='awx')
+    db_user = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    db_password = serializers.CharField(max_length=512, required=False, allow_blank=True, default='')

--- a/src/backend/api/v1/clusters/urls.py
+++ b/src/backend/api/v1/clusters/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import ClusterListCreateView, ClusterDetailView, ClusterSyncView, ClusterTestConnectionView
+
+urlpatterns = [
+    path('', ClusterListCreateView.as_view(), name='cluster-list'),
+    path('<int:pk>/', ClusterDetailView.as_view(), name='cluster-detail'),
+    path('<int:pk>/sync/', ClusterSyncView.as_view(), name='cluster-sync'),
+    path('test_connection/', ClusterTestConnectionView.as_view(), name='cluster-test-connection'),
+]

--- a/src/backend/api/v1/clusters/views.py
+++ b/src/backend/api/v1/clusters/views.py
@@ -145,7 +145,14 @@ class ClusterTestConnectionView(APIView):
                 user=db_user, password=db_password, connect_timeout=10,
             ) as conn:
                 with conn.cursor() as cur:
-                    cur.execute("SELECT 1")
+                    # Verify the user can actually read the tables the sync needs.
+                    # SELECT 1 only proves the socket opened; this query confirms
+                    # SELECT privilege on the three core sync tables.
+                    cur.execute(
+                        "SELECT 1 FROM main_unifiedjob LIMIT 1"
+                    )
+                    cur.execute("SELECT 1 FROM main_job LIMIT 1")
+                    cur.execute("SELECT 1 FROM main_jobhostsummary LIMIT 1")
             return Response({'success': True, 'detected_version': None, 'error': None})
         except Exception:
             logger.exception('Database connectivity test failed for %s', db_host)

--- a/src/backend/api/v1/clusters/views.py
+++ b/src/backend/api/v1/clusters/views.py
@@ -148,7 +148,12 @@ class ClusterTestConnectionView(APIView):
                     cur.execute("SELECT 1")
             return Response({'success': True, 'detected_version': None, 'error': None})
         except Exception as e:
-            return Response({'success': False, 'detected_version': None, 'error': str(e)})
+            logger.exception('Database connectivity test failed')
+            return Response({
+                'success': False,
+                'detected_version': None,
+                'error': 'Database connectivity test failed. Check the connection settings and try again.',
+            })
 
     def _test_api(self, request):
         protocol = request.data.get('protocol', 'https')

--- a/src/backend/api/v1/clusters/views.py
+++ b/src/backend/api/v1/clusters/views.py
@@ -41,9 +41,9 @@ class ClusterListCreateView(APIView):
             aap_version=d['aap_version'],
             verify_ssl=d['verify_ssl'],
             client_id=d['client_id'],
-            client_secret=encrypt_value(d['client_secret']),
-            access_token=encrypt_value(d['access_token']),
-            refresh_token=encrypt_value(d['refresh_token']),
+            client_secret=encrypt_value(d['client_secret']) if d.get('client_secret') else b'',
+            access_token=encrypt_value(d['access_token']) if d.get('access_token') else b'',
+            refresh_token=encrypt_value(d['refresh_token']) if d.get('refresh_token') else b'',
             sync_mode=d.get('sync_mode', 'api'),
             db_host=d.get('db_host', ''),
             db_port=d.get('db_port', 5432),
@@ -147,12 +147,12 @@ class ClusterTestConnectionView(APIView):
                 with conn.cursor() as cur:
                     cur.execute("SELECT 1")
             return Response({'success': True, 'detected_version': None, 'error': None})
-        except Exception as e:
-            logger.exception('Database connectivity test failed')
+        except Exception:
+            logger.exception('Database connectivity test failed for %s', db_host)
             return Response({
                 'success': False,
                 'detected_version': None,
-                'error': 'Database connectivity test failed. Check the connection settings and try again.',
+                'error': 'Database connection failed. Check host, port, credentials and network access.',
             })
 
     def _test_api(self, request):

--- a/src/backend/api/v1/clusters/views.py
+++ b/src/backend/api/v1/clusters/views.py
@@ -1,0 +1,176 @@
+import logging
+
+import requests as http_requests
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from backend.api.v1.permissions import IsAdmin
+from backend.apps.aap_auth.authentication import AAPAuthentication
+from backend.apps.clusters.encryption import encrypt_value
+from backend.apps.clusters.models import Cluster, JobLaunchTypeChoices
+from backend.apps.scheduler.models import SyncJob, JobTypeChoices
+
+from .serializers import ClusterReadSerializer, ClusterWriteSerializer
+
+logger = logging.getLogger('automation_dashboard.api.clusters')
+
+
+class ClusterListCreateView(APIView):
+    authentication_classes = [AAPAuthentication]
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def get(self, request):
+        clusters = Cluster.objects.all().order_by('address')
+        serializer = ClusterReadSerializer(clusters, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = ClusterWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        d = serializer.validated_data
+
+        cluster = Cluster.objects.create(
+            protocol=d['protocol'],
+            address=d['address'],
+            port=d['port'],
+            aap_version=d['aap_version'],
+            verify_ssl=d['verify_ssl'],
+            client_id=d['client_id'],
+            client_secret=encrypt_value(d['client_secret']),
+            access_token=encrypt_value(d['access_token']),
+            refresh_token=encrypt_value(d['refresh_token']),
+            sync_mode=d.get('sync_mode', 'api'),
+            db_host=d.get('db_host', ''),
+            db_port=d.get('db_port', 5432),
+            db_name=d.get('db_name', 'awx'),
+            db_user=d.get('db_user', ''),
+            db_password=encrypt_value(d['db_password']) if d.get('db_password') else b'',
+        )
+        logger.info(f'Created cluster {cluster}')
+
+        return Response(ClusterReadSerializer(cluster).data, status=status.HTTP_201_CREATED)
+
+
+class ClusterDetailView(APIView):
+    authentication_classes = [AAPAuthentication]
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def get(self, request, pk):
+        cluster = get_object_or_404(Cluster, pk=pk)
+        return Response(ClusterReadSerializer(cluster).data, status=status.HTTP_200_OK)
+
+    def patch(self, request, pk):
+        cluster = get_object_or_404(Cluster, pk=pk)
+
+        serializer = ClusterWriteSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        d = serializer.validated_data
+
+        # Update plain fields if present
+        for field in ('protocol', 'address', 'port', 'aap_version', 'verify_ssl', 'client_id',
+                      'sync_mode', 'db_host', 'db_port', 'db_name', 'db_user'):
+            if field in d:
+                setattr(cluster, field, d[field])
+
+        # Update encrypted token fields only when a non-empty value is provided
+        if d.get('access_token'):
+            cluster.access_token = encrypt_value(d['access_token'])
+        if d.get('refresh_token'):
+            cluster.refresh_token = encrypt_value(d['refresh_token'])
+        if d.get('client_secret'):
+            cluster.client_secret = encrypt_value(d['client_secret'])
+        if d.get('db_password'):
+            cluster.db_password = encrypt_value(d['db_password'])
+
+        cluster.save()
+        logger.info(f'Updated cluster {cluster}')
+
+        return Response(ClusterReadSerializer(cluster).data, status=status.HTTP_200_OK)
+
+    def delete(self, request, pk):
+        cluster = get_object_or_404(Cluster, pk=pk)
+        cluster.delete()
+        logger.info(f'Deleted cluster pk={pk}')
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ClusterSyncView(APIView):
+    authentication_classes = [AAPAuthentication]
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def post(self, request, pk):
+        cluster = get_object_or_404(Cluster, pk=pk)
+
+        job = SyncJob.objects.create(
+            name=f'Manual sync for {cluster.address}',
+            type=JobTypeChoices.SYNC_JOBS,
+            launch_type=JobLaunchTypeChoices.MANUAL,
+            cluster=cluster,
+        )
+        job.signal_start()
+        logger.info(f'Enqueued manual sync job {job.pk} for cluster {cluster}')
+
+        return Response({'job_id': job.pk}, status=status.HTTP_202_ACCEPTED)
+
+
+class ClusterTestConnectionView(APIView):
+    authentication_classes = [AAPAuthentication]
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def post(self, request):
+        if request.data.get('sync_mode') == 'database':
+            return self._test_database(request)
+        return self._test_api(request)
+
+    def _test_database(self, request):
+        import psycopg
+        db_host = request.data.get('db_host', '')
+        db_port = request.data.get('db_port', 5432)
+        db_name = request.data.get('db_name', 'awx')
+        db_user = request.data.get('db_user', '')
+        db_password = request.data.get('db_password', '')
+
+        if not db_host or not db_user:
+            return Response({'error': 'db_host and db_user are required'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            with psycopg.connect(
+                host=db_host, port=int(db_port), dbname=db_name,
+                user=db_user, password=db_password, connect_timeout=10,
+            ) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+            return Response({'success': True, 'detected_version': None, 'error': None})
+        except Exception as e:
+            return Response({'success': False, 'detected_version': None, 'error': str(e)})
+
+    def _test_api(self, request):
+        protocol = request.data.get('protocol', 'https')
+        address = request.data.get('address', '')
+        port = request.data.get('port', 443)
+        access_token = request.data.get('access_token', '')
+        verify_ssl = request.data.get('verify_ssl', True)
+
+        if not address or not access_token:
+            return Response({'error': 'address and access_token are required'}, status=status.HTTP_400_BAD_REQUEST)
+
+        base_url = f'{protocol}://{address}:{port}'
+        headers = {'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json', 'Accept': 'application/json'}
+
+        for path, fallback_label in [('/api/gateway/v1/ping/', None), ('/api/v2/ping/', 'AAP 2.4')]:
+            try:
+                response = http_requests.get(f'{base_url}{path}', headers=headers, verify=verify_ssl, timeout=10)
+                if response.ok:
+                    ver = response.json().get('version', '') if fallback_label is None else ''
+                    detected = (f'AAP {ver}' if ver else 'AAP 2.5/2.6') if fallback_label is None else fallback_label
+                    return Response({'success': True, 'detected_version': detected, 'error': None})
+            except http_requests.RequestException:
+                continue
+
+        return Response({'success': False, 'detected_version': None, 'error': 'Could not connect to AAP. Check the host, port, SSL setting, and access token.'})

--- a/src/backend/api/v1/setup/inventory_template.py
+++ b/src/backend/api/v1/setup/inventory_template.py
@@ -1,0 +1,82 @@
+def render_inventory(data: dict) -> str:
+    cluster = data['cluster']
+    sync = data['sync']
+    infra = data['infra']
+
+    protocol = cluster['protocol']
+    address = cluster['address']
+    aap_version_raw = str(cluster['aap_version'])
+    # ClusterVersionChoices stores "AAP 2.5" — strip prefix for inventory var
+    aap_version = aap_version_raw.replace('AAP ', '') if aap_version_raw.startswith('AAP ') else aap_version_raw
+    verify_ssl = str(cluster['verify_ssl']).lower()
+
+    initial_sync_since = sync.get('initial_sync_since')
+    initial_sync_days = sync.get('initial_sync_days', 1)
+
+    dashboard_host = infra['dashboard_host']
+    tls_cert = infra.get('dashboard_tls_cert', '')
+    tls_key = infra.get('dashboard_tls_key', '')
+
+    lines = [
+        '[automationdashboard]',
+        f'{dashboard_host} ansible_connection=local',
+        '',
+        '[automationdashboard:vars]',
+        'aap_auth_provider_name=Ansible Automation Platform',
+        f'aap_auth_provider_protocol={protocol}',
+        f'aap_auth_provider_aap_version={aap_version}',
+        f'aap_auth_provider_host={address}',
+        f'aap_auth_provider_check_ssl={verify_ssl}',
+        f'aap_auth_provider_client_id={cluster["client_id"]}',
+        f'aap_auth_provider_client_secret={cluster["client_secret"]}',
+        '',
+    ]
+
+    if initial_sync_since:
+        lines.append(f'# initial_sync_days={initial_sync_days}')
+        lines.append(f'initial_sync_since={initial_sync_since}')
+    else:
+        lines.append(f'initial_sync_days={initial_sync_days}')
+        lines.append('# initial_sync_since=YYYY-MM-DD')
+
+    lines += [
+        '',
+        f'# nginx_http_port={infra.get("nginx_http_port", 8083)}',
+        f'# nginx_https_port={infra.get("nginx_https_port", 8447)}',
+    ]
+
+    if tls_cert:
+        lines.append(f'dashboard_tls_cert={tls_cert}')
+    else:
+        lines.append('# dashboard_tls_cert=/path/to/tls/dashboard.crt')
+
+    if tls_key:
+        lines.append(f'dashboard_tls_key={tls_key}')
+    else:
+        lines.append('# dashboard_tls_key=/path/to/tls/dashboard.key')
+
+    lines += [
+        '',
+        '[database]',
+        f'{dashboard_host} ansible_connection=local',
+        '',
+        '[redis]',
+        f'{dashboard_host} ansible_connection=local',
+        '',
+        '[all:vars]',
+        'redis_mode=standalone',
+        '',
+        f'postgresql_admin_username={infra["db_admin_username"]}',
+        f'postgresql_admin_password={infra["db_admin_password"]}',
+        '',
+        'dashboard_pg_containerized=True',
+        f'dashboard_admin_password={infra["dashboard_admin_password"]}',
+        f'dashboard_pg_host={infra["db_host"]}',
+        f'dashboard_pg_username={infra["db_username"]}',
+        f'dashboard_pg_password={infra["db_password"]}',
+        f'dashboard_pg_database={infra["db_name"]}',
+        '',
+        'bundle_install=false',
+    ]
+
+    return '\n'.join(lines) + '\n'

--- a/src/backend/api/v1/setup/serializers.py
+++ b/src/backend/api/v1/setup/serializers.py
@@ -1,0 +1,64 @@
+from rest_framework import serializers
+
+from backend.apps.clusters.models import ClusterVersionChoices
+
+
+class ClusterSetupSerializer(serializers.Serializer):
+    protocol = serializers.ChoiceField(choices=['http', 'https'])
+    address = serializers.CharField(max_length=255)
+    port = serializers.IntegerField(default=443, min_value=1, max_value=65535)
+    aap_version = serializers.ChoiceField(choices=ClusterVersionChoices.values)
+    verify_ssl = serializers.BooleanField(default=True)
+    client_id = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    client_secret = serializers.CharField(max_length=1024, required=False, allow_blank=True, default='')
+    access_token = serializers.CharField(max_length=1024, required=False, allow_blank=True, default='')
+    refresh_token = serializers.CharField(max_length=1024, default='')
+    sync_mode = serializers.ChoiceField(choices=['api', 'database'], default='api')
+    db_host = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    db_port = serializers.IntegerField(default=5432, required=False)
+    db_name = serializers.CharField(max_length=255, required=False, allow_blank=True, default='awx')
+    db_user = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
+    db_password = serializers.CharField(max_length=1024, required=False, allow_blank=True, default='')
+
+
+class SyncSetupSerializer(serializers.Serializer):
+    initial_sync_days = serializers.IntegerField(default=1, min_value=1, required=False)
+    initial_sync_since = serializers.DateField(required=False, allow_null=True)
+
+    def validate(self, attrs):
+        if not attrs.get('initial_sync_since') and not attrs.get('initial_sync_days'):
+            attrs['initial_sync_days'] = 1
+        return attrs
+
+
+class CostSetupSerializer(serializers.Serializer):
+    monthly_subscription_cost = serializers.DecimalField(max_digits=20, decimal_places=2, min_value=0.01)
+    engineer_avg_hourly_rate = serializers.DecimalField(max_digits=10, decimal_places=2, min_value=0.01)
+
+
+class InfraSetupSerializer(serializers.Serializer):
+    dashboard_host = serializers.CharField(max_length=255)
+    db_host = serializers.CharField(max_length=255)
+    db_username = serializers.CharField(max_length=255, default='aapdashboard')
+    db_password = serializers.CharField(max_length=255)
+    db_name = serializers.CharField(max_length=255, default='aapdashboard')
+    db_admin_username = serializers.CharField(max_length=255, default='postgres')
+    db_admin_password = serializers.CharField(max_length=255)
+    dashboard_admin_password = serializers.CharField(max_length=255)
+    nginx_http_port = serializers.IntegerField(default=8083, min_value=1, max_value=65535)
+    nginx_https_port = serializers.IntegerField(default=8447, min_value=1, max_value=65535)
+    dashboard_tls_cert = serializers.CharField(required=False, allow_blank=True, default='')
+    dashboard_tls_key = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class SetupConfigureSerializer(serializers.Serializer):
+    cluster = ClusterSetupSerializer()
+    sync = SyncSetupSerializer()
+    costs = CostSetupSerializer()
+
+
+class SetupInventorySerializer(serializers.Serializer):
+    cluster = ClusterSetupSerializer()
+    sync = SyncSetupSerializer()
+    costs = CostSetupSerializer()
+    infra = InfraSetupSerializer()

--- a/src/backend/api/v1/setup/urls.py
+++ b/src/backend/api/v1/setup/urls.py
@@ -1,0 +1,21 @@
+from django.urls import path
+
+from .views import (
+    SetupStatusView,
+    SetupMeView,
+    SetupLocalLoginView,
+    SetupTestConnectionView,
+    SetupConfigureView,
+    SetupInventoryView,
+    SetupSyncProgressView,
+)
+
+urlpatterns = [
+    path('status/', SetupStatusView.as_view(), name='setup-status'),
+    path('me/', SetupMeView.as_view(), name='setup-me'),
+    path('local_login/', SetupLocalLoginView.as_view(), name='setup-local-login'),
+    path('test_connection/', SetupTestConnectionView.as_view(), name='setup-test-connection'),
+    path('configure/', SetupConfigureView.as_view(), name='setup-configure'),
+    path('inventory/', SetupInventoryView.as_view(), name='setup-inventory'),
+    path('sync_progress/', SetupSyncProgressView.as_view(), name='setup-sync-progress'),
+]

--- a/src/backend/api/v1/setup/views.py
+++ b/src/backend/api/v1/setup/views.py
@@ -130,7 +130,9 @@ class SetupTestConnectionView(APIView):
                 )
                 with conn:
                     with conn.cursor() as cur:
-                        cur.execute("SELECT 1")
+                        cur.execute("SELECT 1 FROM main_unifiedjob LIMIT 1")
+                        cur.execute("SELECT 1 FROM main_job LIMIT 1")
+                        cur.execute("SELECT 1 FROM main_jobhostsummary LIMIT 1")
                 return Response({'success': True, 'error': None})
             except Exception as e:
                 logger.warning('Setup DB connection test failed: %s', e)

--- a/src/backend/api/v1/setup/views.py
+++ b/src/backend/api/v1/setup/views.py
@@ -1,0 +1,289 @@
+import json
+import logging
+from datetime import datetime, timezone, timedelta
+
+import psycopg
+import requests as http_requests
+from django.contrib.auth import authenticate, login, get_user
+from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from backend.apps.clusters.encryption import encrypt_value
+from backend.apps.clusters.models import (
+    Cluster, ClusterSyncStatus, SubscriptionCost, JobLaunchTypeChoices,
+)
+from backend.apps.scheduler.models import SyncJob, JobTypeChoices
+from .inventory_template import render_inventory
+from .serializers import SetupConfigureSerializer, SetupInventorySerializer
+
+logger = logging.getLogger('automation_dashboard.setup')
+
+
+class SessionAuthNoCSRF(SessionAuthentication):
+    """SessionAuthentication without CSRF enforcement — safe for setup wizard endpoints
+    that are only reachable when no clusters exist (setup_required=true)."""
+    def enforce_csrf(self, request):
+        pass
+
+
+def _session_user(request):
+    """Read the authenticated user from the Django session directly, bypassing DRF auth."""
+    django_request = getattr(request, '_request', request)
+    return get_user(django_request)
+
+
+def _is_superuser(request) -> bool:
+    user = _session_user(request)
+    return bool(user and user.is_authenticated and user.is_superuser)
+
+
+class SetupStatusView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        return Response({'setup_required': Cluster.objects.count() == 0})
+
+
+class SetupMeView(APIView):
+    """Returns the current Django session user — used by the setup wizard to check auth state."""
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        user = _session_user(request)
+        if user and user.is_authenticated:
+            return Response({
+                'authenticated': True,
+                'is_superuser': user.is_superuser,
+                'username': user.username,
+            })
+        return Response({'authenticated': False, 'is_superuser': False, 'username': None})
+
+
+class SetupLocalLoginView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        if Cluster.objects.count() > 0:
+            return Response({'error': 'Setup already complete'}, status=status.HTTP_403_FORBIDDEN)
+
+        username = request.data.get('username', '')
+        password = request.data.get('password', '')
+
+        if not username or not password:
+            return Response({'error': 'Username and password are required'}, status=status.HTTP_400_BAD_REQUEST)
+
+        django_request = getattr(request, '_request', request)
+        user = authenticate(django_request, username=username, password=password)
+        if user is None or not user.is_superuser:
+            return Response(
+                {'error': 'Invalid credentials or user is not a superuser'},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        login(django_request, user)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class SetupTestConnectionView(APIView):
+    authentication_classes = [SessionAuthNoCSRF]
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        if not _is_superuser(request):
+            return Response({'error': 'Superuser session required'}, status=status.HTTP_403_FORBIDDEN)
+
+        sync_mode = request.data.get('sync_mode', 'api')
+
+        # --- Database-direct connection test ---
+        if sync_mode == 'database':
+            db_host = request.data.get('db_host', '')
+            db_port = request.data.get('db_port', 5432)
+            db_name = request.data.get('db_name', 'awx')
+            db_user = request.data.get('db_user', '')
+            db_password = request.data.get('db_password', '')
+
+            if not db_host or not db_user:
+                return Response(
+                    {'error': 'db_host and db_user are required for database mode'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            try:
+                conn = psycopg.connect(
+                    host=db_host,
+                    port=int(db_port),
+                    dbname=db_name,
+                    user=db_user,
+                    password=db_password,
+                    connect_timeout=10,
+                )
+                with conn:
+                    with conn.cursor() as cur:
+                        cur.execute("SELECT 1")
+                return Response({'success': True, 'error': None})
+            except Exception as e:
+                return Response({'success': False, 'error': str(e)})
+
+        # --- API (OAuth2) connection test ---
+        protocol = request.data.get('protocol', 'https')
+        address = request.data.get('address', '')
+        port = request.data.get('port', 443)
+        access_token = request.data.get('access_token', '')
+        verify_ssl = request.data.get('verify_ssl', True)
+
+        if not address or not access_token:
+            return Response(
+                {'error': 'address and access_token are required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        base_url = f'{protocol}://{address}:{port}'
+        headers = {
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }
+
+        # Try AAP 2.5/2.6 first, then 2.4
+        for path, fallback_label in [('/api/gateway/v1/ping/', None), ('/api/v2/ping/', 'AAP 2.4')]:
+            try:
+                response = http_requests.get(
+                    f'{base_url}{path}',
+                    headers=headers,
+                    verify=verify_ssl,
+                    timeout=10,
+                )
+                if response.ok:
+                    if fallback_label is None:
+                        ver = response.json().get('version', '')
+                        detected = f'AAP {ver}' if ver else 'AAP 2.5/2.6'
+                    else:
+                        detected = fallback_label
+                    return Response({'success': True, 'detected_version': detected, 'error': None})
+            except http_requests.RequestException:
+                continue
+
+        return Response({
+            'success': False,
+            'detected_version': None,
+            'error': 'Could not connect to AAP. Check the host, port, SSL setting, and access token.',
+        })
+
+
+class SetupConfigureView(APIView):
+    authentication_classes = [SessionAuthNoCSRF]
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        if not _is_superuser(request):
+            return Response({'error': 'Superuser session required'}, status=status.HTTP_403_FORBIDDEN)
+
+        if Cluster.objects.count() > 0:
+            return Response({'error': 'Cluster already configured'}, status=status.HTTP_409_CONFLICT)
+
+        serializer = SetupConfigureSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        d = serializer.validated_data
+
+        c = d['cluster']
+        cluster = Cluster.objects.create(
+            protocol=c['protocol'],
+            address=c['address'],
+            port=c['port'],
+            aap_version=c['aap_version'],
+            verify_ssl=c['verify_ssl'],
+            client_id=c['client_id'],
+            client_secret=encrypt_value(c['client_secret']) if c.get('client_secret') else b'',
+            access_token=encrypt_value(c['access_token']) if c.get('access_token') else b'',
+            refresh_token=encrypt_value(c['refresh_token']) if c.get('refresh_token') else b'',
+            sync_mode=c.get('sync_mode', 'api'),
+            db_host=c.get('db_host', ''),
+            db_port=c.get('db_port', 5432),
+            db_name=c.get('db_name', 'awx'),
+            db_user=c.get('db_user', ''),
+            db_password=encrypt_value(c['db_password']) if c.get('db_password') else b'',
+        )
+        logger.info(f'Setup: created cluster {cluster}')
+
+        cost = SubscriptionCost.get()
+        cost.monthly_subscription_cost = d['costs']['monthly_subscription_cost']
+        cost.engineer_avg_hourly_rate = d['costs']['engineer_avg_hourly_rate']
+        cost.save()
+        logger.info('Setup: saved subscription cost')
+
+        sync_data = d['sync']
+        since_date = sync_data.get('initial_sync_since')
+        if since_date is not None:
+            since_dt = datetime.combine(since_date, datetime.min.time()).replace(tzinfo=timezone.utc)
+        else:
+            days = sync_data.get('initial_sync_days', 1)
+            since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+
+        until_dt = datetime.now(timezone.utc).replace(hour=23, minute=59, second=59, microsecond=0)
+
+        job_args = json.dumps({
+            'since': since_dt.isoformat(),
+            'until': until_dt.isoformat(),
+            'managed': True,
+        })
+
+        job = SyncJob.objects.create(
+            name=f'Initial sync since {since_dt.date().isoformat()}',
+            type=JobTypeChoices.SYNC_JOBS,
+            launch_type=JobLaunchTypeChoices.MANUAL,
+            cluster=cluster,
+            job_args=job_args,
+        )
+        job.signal_start()
+        logger.info(f'Setup: enqueued initial sync job {job.pk}')
+
+        return Response(status=status.HTTP_201_CREATED)
+
+
+class SetupInventoryView(APIView):
+    authentication_classes = [SessionAuthNoCSRF]
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        if not _is_superuser(request):
+            return Response({'error': 'Superuser session required'}, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = SetupInventorySerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        content = render_inventory(serializer.validated_data)
+        response = Response(content, content_type='text/plain; charset=utf-8')
+        response['Content-Disposition'] = 'attachment; filename=inventory'
+        return response
+
+
+class SetupSyncProgressView(APIView):
+    authentication_classes = [SessionAuthNoCSRF]
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        if not _is_superuser(request):
+            return Response({'error': 'Superuser session required'}, status=status.HTTP_403_FORBIDDEN)
+
+        cluster = Cluster.objects.first()
+        if cluster is None:
+            return Response({'has_synced': False, 'last_synced': None, 'cluster_configured': False})
+
+        try:
+            sync_status = ClusterSyncStatus.objects.get(cluster=cluster)
+            return Response({
+                'has_synced': True,
+                'last_synced': sync_status.last_job_finished_date.isoformat(),
+                'cluster_configured': True,
+            })
+        except ClusterSyncStatus.DoesNotExist:
+            return Response({'has_synced': False, 'last_synced': None, 'cluster_configured': True})

--- a/src/backend/api/v1/setup/views.py
+++ b/src/backend/api/v1/setup/views.py
@@ -23,10 +23,15 @@ logger = logging.getLogger('automation_dashboard.setup')
 
 
 class SessionAuthNoCSRF(SessionAuthentication):
-    """SessionAuthentication without CSRF enforcement — safe for setup wizard endpoints
-    that are only reachable when no clusters exist (setup_required=true)."""
+    """SessionAuthentication for setup wizard endpoints.
+
+    Delegates CSRF enforcement to the shared enforce_csrf() helper (double-submit
+    cookie, supports both X-CSRFToken and X-XSRF-TOKEN) rather than using
+    Django's CsrfViewMiddleware which fails on origin checks for localhost.
+    """
     def enforce_csrf(self, request):
-        pass
+        from backend.apps.aap_auth.authentication import enforce_csrf
+        enforce_csrf(request)
 
 
 def _session_user(request):
@@ -128,7 +133,8 @@ class SetupTestConnectionView(APIView):
                         cur.execute("SELECT 1")
                 return Response({'success': True, 'error': None})
             except Exception as e:
-                return Response({'success': False, 'error': str(e)})
+                logger.warning('Setup DB connection test failed: %s', e)
+                return Response({'success': False, 'error': 'Database connection failed. Check host, port, credentials and network access.'})
 
         # --- API (OAuth2) connection test ---
         protocol = request.data.get('protocol', 'https')

--- a/src/backend/api/v1/urls.py
+++ b/src/backend/api/v1/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
     path("projects/", include("backend.api.v1.projects.urls")),
     path("organizations/", include("backend.api.v1.organizations.urls")),
     path("metrics/", include("backend.api.v1.metrics.urls")),
+    path("setup/", include("backend.api.v1.setup.urls")),
+    path("clusters/", include("backend.api.v1.clusters.urls")),
     re_path(r'^schema/$', schema_view, name='schema-json'),
     re_path(r'^docs/$', swagger_ui_view, name='schema-swagger-ui'),
     re_path(r'^redoc/$', redoc_view, name='schema-redoc'),

--- a/src/backend/apps/aap_auth/authentication.py
+++ b/src/backend/apps/aap_auth/authentication.py
@@ -12,15 +12,27 @@ logger = logging.getLogger("automation_dashboard.auth")
 
 def enforce_csrf(request):
     """
-    Enforce CSRF validation.
+    Enforce CSRF validation using the double-submit cookie pattern.
+
+    Compares the csrftoken cookie against the token sent in the request header.
+    Accepts both X-CSRFToken (Django default) and X-XSRF-TOKEN (axios default)
+    so that browser clients work without extra configuration.
     """
     logger.info("Starting CSRF validation.")
-    check = CSRFCheck(request)
-    check.process_request(request)
-    reason = check.process_view(request, None, (), {})
-    if reason:
-        logger.error('CSRF Failed: %s' % reason)
-        raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
+
+    cookie_token = request.COOKIES.get('csrftoken', '')
+    if not cookie_token:
+        # No CSRF cookie present — nothing to validate against.
+        return
+
+    header_token = (
+        request.META.get('HTTP_X_XSRF_TOKEN', '')
+        or request.META.get('HTTP_X_CSRFTOKEN', '')
+    )
+
+    if not header_token or header_token != cookie_token:
+        logger.error('CSRF Failed: token mismatch or missing header')
+        raise exceptions.PermissionDenied('CSRF Failed: token mismatch')
 
 
 class AAPAuthentication(BaseAuthentication):

--- a/src/backend/apps/aap_auth/authentication.py
+++ b/src/backend/apps/aap_auth/authentication.py
@@ -10,20 +10,30 @@ from backend.apps.aap_auth.jwt_token import JWTToken
 logger = logging.getLogger("automation_dashboard.auth")
 
 
+_CSRF_SAFE_METHODS = frozenset({'GET', 'HEAD', 'OPTIONS', 'TRACE'})
+
+
 def enforce_csrf(request):
     """
     Enforce CSRF validation using the double-submit cookie pattern.
 
-    Compares the csrftoken cookie against the token sent in the request header.
-    Accepts both X-CSRFToken (Django default) and X-XSRF-TOKEN (axios default)
-    so that browser clients work without extra configuration.
+    Safe methods (GET, HEAD, OPTIONS, TRACE) are exempt.  For all other methods
+    the csrftoken cookie must be present and must match the token sent in either
+    X-CSRFToken (Django default) or X-XSRF-TOKEN (axios default).
+
+    Silently skipping validation when the cookie is absent would allow any
+    unauthenticated cross-site request to bypass CSRF entirely, so we treat a
+    missing cookie as a hard failure for state-changing methods.
     """
     logger.info("Starting CSRF validation.")
 
+    if request.method in _CSRF_SAFE_METHODS:
+        return
+
     cookie_token = request.COOKIES.get('csrftoken', '')
     if not cookie_token:
-        # No CSRF cookie present — nothing to validate against.
-        return
+        logger.error('CSRF Failed: csrftoken cookie is absent')
+        raise exceptions.PermissionDenied('CSRF Failed: missing CSRF cookie')
 
     header_token = (
         request.META.get('HTTP_X_XSRF_TOKEN', '')

--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -326,17 +326,21 @@ class ApiConnector:
         return response
 
     def detect_aap_version(self):
-        logger.info(f'Checking if is AAP 2.5 ... 2.6 at {self.cluster.base_url}')
+        logger.info(f'Checking if is AAP 2.5+ at {self.cluster.base_url}')
         response25 = self.ping("/api/gateway/v1/ping/")
         if response25:
-            logger.debug(f"AAP 2.5/2.6 ping response: {response25}")
-            if response25["version"] == "2.6":
-                return ClusterVersionChoices.AAP26
-            elif response25["version"] == "2.5":
-                return ClusterVersionChoices.AAP25
+            logger.debug(f"AAP 2.5+ ping response: {response25}")
+            version_map = {
+                "2.7": ClusterVersionChoices.AAP27,
+                "2.6": ClusterVersionChoices.AAP26,
+                "2.5": ClusterVersionChoices.AAP25,
+            }
+            ver = response25.get("version", "")
+            if ver in version_map:
+                return version_map[ver]
             else:
-                logger.error(f'Not valid version {response25["version"]} for cluster {self.cluster.base_url}.')
-                raise Exception(f'Not valid version {response25["version"]} for cluster {self.cluster.base_url}.')
+                logger.error(f'Not valid version {ver} for cluster {self.cluster.base_url}.')
+                raise Exception(f'Not valid version {ver} for cluster {self.cluster.base_url}.')
 
         logger.info(f'Checking if is AAP 2.4 at {self.cluster.base_url}')
         response24 = self.ping("/api/v2/ping/")

--- a/src/backend/apps/clusters/db_connector.py
+++ b/src/backend/apps/clusters/db_connector.py
@@ -1,0 +1,451 @@
+import datetime
+import logging
+
+import psycopg
+import psycopg.rows
+import pytz
+
+from backend.apps.clusters.encryption import decrypt_value
+from backend.apps.clusters.models import (
+    AAPUser,
+    Cluster,
+    ClusterSyncStatus,
+    ExecutionEnvironment,
+    Host,
+    InstanceGroup,
+    Inventory,
+    Job,
+    JobHostSummary,
+    JobLabel,
+    JobLaunchTypeChoices,
+    JobRunTypeChoices,
+    JobStatusChoices,
+    JobTemplate,
+    JobTypeChoices,
+    Label,
+    Organization,
+    Project,
+)
+
+logger = logging.getLogger('automation_dashboard.db_connector')
+
+
+class DbConnector:
+    """Reads job data directly from AAP's PostgreSQL database."""
+
+    def __init__(
+        self,
+        cluster: Cluster,
+        since: datetime.datetime | None = None,
+        until: datetime.datetime | None = None,
+    ):
+        self.cluster = cluster
+        self.until = until or datetime.datetime.now(pytz.UTC)
+
+        # Determine since from ClusterSyncStatus or provided value
+        if since is not None:
+            self.since = since
+        else:
+            try:
+                sync_status = ClusterSyncStatus.objects.get(cluster=cluster)
+                self.since = sync_status.last_job_finished_date
+            except ClusterSyncStatus.DoesNotExist:
+                self.since = self.until - datetime.timedelta(days=1)
+
+    def _get_connection(self):
+        return psycopg.connect(
+            host=self.cluster.db_host,
+            port=self.cluster.db_port,
+            dbname=self.cluster.db_name,
+            user=self.cluster.db_user,
+            password=decrypt_value(bytes(self.cluster.db_password)),
+            row_factory=psycopg.rows.dict_row,
+            connect_timeout=10,
+        )
+
+    def check_connection(self):
+        """Test the database connection. Returns (success: bool, error: str | None)."""
+        try:
+            with self._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def sync(self):
+        """Main sync entry point. Connects and syncs all data."""
+        logger.info(f'DbConnector: syncing cluster {self.cluster} from {self.since} to {self.until}')
+        with self._get_connection() as conn:
+            self._sync_organizations(conn)
+            self._sync_job_templates(conn)
+            self._sync_jobs(conn)
+        logger.info(f'DbConnector: sync complete for cluster {self.cluster}')
+
+    def _sync_organizations(self, conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, name, COALESCE(description, '') as description"
+                " FROM main_organization ORDER BY name"
+            )
+            rows = cur.fetchall()
+        for row in rows:
+            Organization.create_or_update(
+                cluster=self.cluster,
+                external_id=row['id'],
+                name=row['name'],
+                description=row['description'],
+            )
+        logger.info(f'DbConnector: synced {len(rows)} organizations')
+
+    def _sync_job_templates(self, conn):
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT ujt.id, ujt.name, COALESCE(ujt.description, '') as description,
+                       ujt.organization_id
+                FROM main_unifiedjobtemplate ujt
+                JOIN main_jobtemplate jt ON jt.unifiedjobtemplate_ptr_id = ujt.id
+                ORDER BY ujt.name
+            """)
+            rows = cur.fetchall()
+        for row in rows:
+            org = None
+            if row['organization_id']:
+                try:
+                    org = Organization.objects.get(cluster=self.cluster, external_id=row['organization_id'])
+                except Organization.DoesNotExist:
+                    pass
+            JobTemplate.create_or_update(
+                cluster=self.cluster,
+                external_id=row['id'],
+                name=row['name'],
+                description=row['description'],
+                organization=org,
+            )
+        logger.info(f'DbConnector: synced {len(rows)} job templates')
+
+    def _sync_jobs(self, conn):
+        JOBS_SQL = """
+            SELECT
+                uj.id,
+                uj.status,
+                uj.failed,
+                uj.started,
+                uj.finished,
+                uj.elapsed,
+                uj.launch_type,
+                uj.created,
+                uj.modified,
+                COALESCE(ujt.name, '') as name,
+                COALESCE(ujt.description, '') as description,
+                COALESCE(j.job_type, 'run') as job_type,
+                uj.organization_id,
+                j.job_template_id,
+                j.inventory_id,
+                uj.execution_environment_id,
+                uj.instance_group_id,
+                j.project_id,
+                uj.created_by_id,
+                uj.polymorphic_ctype_id
+            FROM main_unifiedjob uj
+            JOIN main_job j ON j.unifiedjob_ptr_id = uj.id
+            LEFT JOIN main_jobtemplate jt ON jt.unifiedjobtemplate_ptr_id = j.job_template_id
+            LEFT JOIN main_unifiedjobtemplate ujt ON ujt.id = j.job_template_id
+            WHERE uj.finished > %(since)s
+              AND uj.finished <= %(until)s
+              AND uj.status IN ('successful', 'failed', 'error', 'canceled')
+            ORDER BY uj.finished
+        """
+        with conn.cursor() as cur:
+            cur.execute(JOBS_SQL, {'since': self.since, 'until': self.until})
+            job_rows = cur.fetchall()
+
+        latest_finished = None
+
+        for row in job_rows:
+            job = self._sync_single_job(conn, row)
+            if job and row['finished']:
+                finished = row['finished']
+                if finished.tzinfo is None:
+                    finished = finished.replace(tzinfo=pytz.UTC)
+                if latest_finished is None or finished > latest_finished:
+                    latest_finished = finished
+
+        if latest_finished:
+            ClusterSyncStatus.objects.update_or_create(
+                cluster=self.cluster,
+                defaults={'last_job_finished_date': latest_finished},
+            )
+
+        logger.info(f'DbConnector: synced {len(job_rows)} jobs')
+
+    def _sync_single_job(self, conn, row):
+        # Resolve foreign key objects
+        org = self._get_or_create_org(row['organization_id'])
+        job_template = self._get_job_template(row['job_template_id'])
+        inventory = self._get_or_create_inventory(conn, row['inventory_id'])
+        ee = self._get_or_create_ee(conn, row['execution_environment_id'])
+        ig = self._get_or_create_instance_group(conn, row['instance_group_id'])
+        project = self._get_or_create_project(conn, row['project_id'])
+        launched_by = self._get_or_create_user(conn, row['created_by_id'])
+
+        # Map status — fall back to FAILED for unrecognised values
+        valid_statuses = [c.value for c in JobStatusChoices]
+        status = row['status'] if row['status'] in valid_statuses else JobStatusChoices.FAILED
+
+        # Host summary aggregates
+        hs_agg = self._get_host_summary_aggregates(conn, row['id'])
+
+        job_data = dict(
+            type=JobTypeChoices.JOB,
+            job_type=row['job_type'] or JobRunTypeChoices.RUN,
+            launch_type=row['launch_type'] or JobLaunchTypeChoices.MANUAL,
+            name=row['name'] or '',
+            description=row['description'] or '',
+            organization=org,
+            job_template=job_template,
+            inventory=inventory,
+            execution_environment=ee,
+            instance_group=ig,
+            project=project,
+            launched_by=launched_by,
+            status=status,
+            started=row['started'],
+            finished=row['finished'],
+            elapsed=row['elapsed'] or 0,
+            failed=row['failed'],
+            created=row['created'],
+            modified=row['modified'],
+            num_hosts=hs_agg['num_hosts'],
+            changed_hosts_count=hs_agg['changed'],
+            dark_hosts_count=hs_agg['dark'],
+            failures_hosts_count=hs_agg['failures'],
+            ok_hosts_count=hs_agg['ok'],
+            processed_hosts_count=hs_agg['processed'],
+            skipped_hosts_count=hs_agg['skipped'],
+            failed_hosts_count=hs_agg['failed_count'],
+            ignored_hosts_count=hs_agg['ignored'],
+            rescued_hosts_count=hs_agg['rescued'],
+        )
+
+        job, _ = Job.objects.update_or_create(
+            cluster=self.cluster,
+            external_id=row['id'],
+            defaults=job_data,
+        )
+
+        # Sync labels and host summaries
+        self._sync_job_labels(conn, job, row['id'])
+        self._sync_host_summaries(conn, job, row['id'])
+
+        return job
+
+    def _get_host_summary_aggregates(self, conn, job_id):
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) as num_hosts,
+                       COALESCE(SUM(changed), 0) as changed,
+                       COALESCE(SUM(dark), 0) as dark,
+                       COALESCE(SUM(failures), 0) as failures,
+                       COALESCE(SUM(ok), 0) as ok,
+                       COALESCE(SUM(processed), 0) as processed,
+                       COALESCE(SUM(skipped), 0) as skipped,
+                       COALESCE(SUM(CASE WHEN failed THEN 1 ELSE 0 END), 0) as failed_count,
+                       COALESCE(SUM(ignored), 0) as ignored,
+                       COALESCE(SUM(rescued), 0) as rescued
+                FROM main_jobhostsummary WHERE job_id = %(job_id)s
+            """, {'job_id': job_id})
+            row = cur.fetchone()
+        return row or {
+            'num_hosts': 0,
+            'changed': 0,
+            'dark': 0,
+            'failures': 0,
+            'ok': 0,
+            'processed': 0,
+            'skipped': 0,
+            'failed_count': 0,
+            'ignored': 0,
+            'rescued': 0,
+        }
+
+    def _sync_host_summaries(self, conn, job, job_id):
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT hs.id, hs.host_name, hs.host_id, hs.changed, hs.dark, hs.failures,
+                       hs.ok, hs.processed, hs.skipped, hs.failed, hs.ignored, hs.rescued,
+                       hs.created, hs.modified, h.name as h_name
+                FROM main_jobhostsummary hs
+                LEFT JOIN main_host h ON h.id = hs.host_id
+                WHERE hs.job_id = %(job_id)s
+            """, {'job_id': job_id})
+            rows = cur.fetchall()
+        for row in rows:
+            host = None
+            if row['host_id']:
+                host, _ = Host.objects.get_or_create(
+                    cluster=self.cluster,
+                    external_id=row['host_id'],
+                    defaults={'name': row['h_name'] or row['host_name'] or ''},
+                )
+            JobHostSummary.objects.update_or_create(
+                job=job,
+                host=host,
+                host_name=row['host_name'] or '',
+                defaults=dict(
+                    changed=row['changed'] or 0,
+                    dark=row['dark'] or 0,
+                    failures=row['failures'] or 0,
+                    ok=row['ok'] or 0,
+                    processed=row['processed'] or 0,
+                    skipped=row['skipped'] or 0,
+                    failed=row['failed'] or False,
+                    ignored=row['ignored'] or 0,
+                    rescued=row['rescued'] or 0,
+                    created=row['created'],
+                    modified=row['modified'],
+                ),
+            )
+
+    def _sync_job_labels(self, conn, job, job_id):
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT l.id, l.name FROM main_label l
+                JOIN main_unifiedjob_labels ul ON ul.label_id = l.id
+                WHERE ul.unifiedjob_id = %(job_id)s
+            """, {'job_id': job_id})
+            rows = cur.fetchall()
+        JobLabel.objects.filter(job=job).delete()
+        for row in rows:
+            label, _ = Label.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                defaults={'name': row['name']},
+            )
+            JobLabel.objects.get_or_create(job=job, label=label)
+
+    # --- FK helpers ---
+
+    def _get_or_create_org(self, org_id):
+        if not org_id:
+            return None
+        try:
+            return Organization.objects.get(cluster=self.cluster, external_id=org_id)
+        except Organization.DoesNotExist:
+            return None
+
+    def _get_job_template(self, jt_id):
+        if not jt_id:
+            return None
+        try:
+            return JobTemplate.objects.get(cluster=self.cluster, external_id=jt_id)
+        except JobTemplate.DoesNotExist:
+            return None
+
+    def _get_or_create_inventory(self, conn, inv_id):
+        if not inv_id:
+            return None
+        try:
+            return Inventory.objects.get(cluster=self.cluster, external_id=inv_id)
+        except Inventory.DoesNotExist:
+            pass
+        with conn.cursor() as cur:
+            cur.execute("SELECT id, name FROM main_inventory WHERE id = %(id)s", {'id': inv_id})
+            row = cur.fetchone()
+        if row:
+            inv, _ = Inventory.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                defaults={'name': row['name']},
+            )
+            return inv
+        return None
+
+    def _get_or_create_ee(self, conn, ee_id):
+        if not ee_id:
+            return None
+        try:
+            return ExecutionEnvironment.objects.get(cluster=self.cluster, external_id=ee_id)
+        except ExecutionEnvironment.DoesNotExist:
+            pass
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, image FROM main_executionenvironment WHERE id = %(id)s",
+                {'id': ee_id},
+            )
+            row = cur.fetchone()
+        if row:
+            ee, _ = ExecutionEnvironment.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                defaults={'name': row['image'] or ''},
+            )
+            return ee
+        return None
+
+    def _get_or_create_instance_group(self, conn, ig_id):
+        if not ig_id:
+            return None
+        try:
+            return InstanceGroup.objects.get(cluster=self.cluster, external_id=ig_id)
+        except InstanceGroup.DoesNotExist:
+            pass
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, name, is_container_group FROM main_instancegroup WHERE id = %(id)s",
+                {'id': ig_id},
+            )
+            row = cur.fetchone()
+        if row:
+            ig, _ = InstanceGroup.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                defaults={'name': row['name'], 'is_container_group': row['is_container_group']},
+            )
+            return ig
+        return None
+
+    def _get_or_create_project(self, conn, proj_id):
+        if not proj_id:
+            return None
+        try:
+            return Project.objects.get(cluster=self.cluster, external_id=proj_id)
+        except Project.DoesNotExist:
+            pass
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, name, COALESCE(scm_type, '') as scm_type FROM main_project WHERE id = %(id)s",
+                {'id': proj_id},
+            )
+            row = cur.fetchone()
+        if row:
+            proj, _ = Project.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                defaults={'name': row['name'], 'scm_type': row['scm_type']},
+            )
+            return proj
+        return None
+
+    def _get_or_create_user(self, conn, user_id):
+        if not user_id:
+            return None
+        try:
+            return AAPUser.objects.get(cluster=self.cluster, external_id=user_id, type='user')
+        except AAPUser.DoesNotExist:
+            pass
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, username FROM auth_user WHERE id = %(id)s",
+                {'id': user_id},
+            )
+            row = cur.fetchone()
+        if row:
+            user, _ = AAPUser.objects.get_or_create(
+                cluster=self.cluster,
+                external_id=row['id'],
+                type='user',
+                defaults={'name': row['username']},
+            )
+            return user
+        return None

--- a/src/backend/apps/clusters/migrations/0025_cluster_db_sync_fields.py
+++ b/src/backend/apps/clusters/migrations/0025_cluster_db_sync_fields.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clusters', '0024_delete_costs'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cluster',
+            name='sync_mode',
+            field=models.CharField(
+                choices=[('api', 'API (OAuth2)'), ('database', 'Direct Database')],
+                default='api',
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name='cluster',
+            name='db_host',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='cluster',
+            name='db_port',
+            field=models.IntegerField(default=5432),
+        ),
+        migrations.AddField(
+            model_name='cluster',
+            name='db_name',
+            field=models.CharField(blank=True, default='awx', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='cluster',
+            name='db_user',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='cluster',
+            name='db_password',
+            field=models.BinaryField(default=b''),
+        ),
+    ]

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -61,9 +61,15 @@ class CreatUpdateModel(models.Model):
 
 
 class ClusterVersionChoices(models.TextChoices):
+    AAP27 = "AAP 2.7", "AAP 2.7"
     AAP26 = "AAP 2.6", "AAP 2.6"
     AAP25 = "AAP 2.5", "AAP 2.5"
     AAP24 = "AAP 2.4", "AAP 2.4"
+
+
+class SyncModeChoices(models.TextChoices):
+    API = 'api', 'API (OAuth2)'
+    DATABASE = 'database', 'Direct Database'
 
 
 class Cluster(CreatUpdateModel):
@@ -77,6 +83,12 @@ class Cluster(CreatUpdateModel):
     verify_ssl = models.BooleanField(default=True)
     aap_version = models.CharField(max_length=15, choices=ClusterVersionChoices.choices,
                                    default=ClusterVersionChoices.AAP24)
+    sync_mode = models.CharField(max_length=20, choices=SyncModeChoices.choices, default=SyncModeChoices.API)
+    db_host = models.CharField(max_length=255, blank=True, default='')
+    db_port = models.IntegerField(default=5432)
+    db_name = models.CharField(max_length=255, blank=True, default='awx')
+    db_user = models.CharField(max_length=255, blank=True, default='')
+    db_password = models.BinaryField(default=b'')
 
     def __str__(self):
         return f'{self.protocol}://{self.address}:{self.port}'
@@ -87,7 +99,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def api_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return f'/api/controller/v2'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'/api/v2'
@@ -96,7 +108,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def gui_base_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return f'{self.base_url}/execution/'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'{self.base_url}/#/'
@@ -105,7 +117,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def oauth_token_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return '/o/token/'
         elif self.aap_version in [ClusterVersionChoices.AAP24]:
             return '/api/o/token/'

--- a/src/backend/apps/clusters/schemas.py
+++ b/src/backend/apps/clusters/schemas.py
@@ -28,7 +28,7 @@ class ClusterSettings(FrozenModel):
 
 
 class ClusterSchema(ClusterSettings):
-    aap_version: Literal["AAP 2.6", "AAP 2.5", "AAP 2.4"] | None = None
+    aap_version: Literal["AAP 2.7", "AAP 2.6", "AAP 2.5", "AAP 2.4"] | None = None
     api_url: str
     base_url: str
 

--- a/src/backend/apps/tasks/jobs.py
+++ b/src/backend/apps/tasks/jobs.py
@@ -8,7 +8,7 @@ from django.db import transaction
 
 from backend.analytics.subsystem_metrics import DispatcherMetrics
 from backend.apps.clusters.connector import ApiConnector
-from backend.apps.clusters.models import JobStatusChoices
+from backend.apps.clusters.models import JobStatusChoices, SyncModeChoices
 from backend.apps.clusters.parser import DataParser
 from backend.apps.scheduler.models import SyncJob
 from backend.utils.update_models import update_model
@@ -88,6 +88,35 @@ class AAPSyncTask(BaseTask):
     prefix = "automation_dashboard_sync_job"
 
     def run_task(self):
+        # --- Database-direct sync mode ---
+        if self.cluster.sync_mode == SyncModeChoices.DATABASE:
+            from backend.apps.clusters.db_connector import DbConnector
+            from datetime import datetime, timezone as _tz
+            job_args = self.instance.get_job_args or {}
+            since = None
+            until = None
+
+            def _to_dt(val):
+                if val is None:
+                    return None
+                if isinstance(val, datetime):
+                    return val if val.tzinfo else val.replace(tzinfo=_tz.utc)
+                return datetime.fromisoformat(str(val)).replace(tzinfo=_tz.utc)
+
+            since = _to_dt(job_args.get('since'))
+            until = _to_dt(job_args.get('until'))
+            try:
+                db_connector = DbConnector(cluster=self.cluster, since=since, until=until)
+                db_connector.sync()
+            except Exception:
+                msg = f'Database sync failed for cluster {self.cluster}'
+                logger.exception(msg)
+                self.update_model(self.instance.pk, status=JobStatusChoices.FAILED, explanation=msg)
+                return
+            self.update_model(self.instance.pk, status=JobStatusChoices.SUCCESSFUL)
+            return
+
+        # --- API (OAuth2) sync mode ---
         job_args = self.instance.get_job_args
 
         if job_args is None:

--- a/src/backend/django_config/settings.py
+++ b/src/backend/django_config/settings.py
@@ -32,6 +32,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
+# Allow the local-account dev login bypass. Set to True only in development.
+ALLOW_DEV_LOGIN = False
+
 
 ALLOWED_HOSTS = [
     'localhost',

--- a/src/backend/tests/unit/test_cluster_views.py
+++ b/src/backend/tests/unit/test_cluster_views.py
@@ -1,0 +1,138 @@
+import json
+from unittest import mock
+
+import pytest
+from rest_framework.test import APIClient
+
+from backend.api.v1.clusters.serializers import ClusterReadSerializer, ClusterWriteSerializer
+from backend.apps.clusters.encryption import encrypt_value
+from backend.apps.clusters.models import Cluster
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def mock_aap_auth(superuser):
+    with mock.patch("backend.apps.aap_auth.authentication.AAPAuthentication.authenticate") as m:
+        m.return_value = superuser, None
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid cluster payload (api mode, no token fields required)
+# ---------------------------------------------------------------------------
+
+_CLUSTER_PAYLOAD = {
+    'protocol': 'https',
+    'address': 'aap.example.com',
+    'port': 443,
+    'aap_version': 'AAP 2.5',
+    'verify_ssl': True,
+    'sync_mode': 'api',
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+class TestClusterViews:
+
+    # ------------------------------------------------------------------
+    # ClusterListCreateView  GET /api/v1/clusters/
+    # ------------------------------------------------------------------
+
+    def test_list_clusters_empty(self, mock_aap_auth, api_client):
+        response = api_client.get('/api/v1/clusters/')
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_clusters_returns_clusters(self, mock_aap_auth, api_client, cluster):
+        response = api_client.get('/api/v1/clusters/')
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]['address'] == 'localhost'
+
+    # ------------------------------------------------------------------
+    # ClusterListCreateView  POST /api/v1/clusters/
+    # ------------------------------------------------------------------
+
+    def test_create_cluster_api_mode(self, mock_aap_auth, api_client):
+        response = api_client.post(
+            '/api/v1/clusters/',
+            data=json.dumps(_CLUSTER_PAYLOAD),
+            content_type='application/json',
+        )
+        assert response.status_code == 201
+        # Verify the cluster was actually stored in the database
+        assert Cluster.objects.filter(address='aap.example.com').exists()
+
+    def test_create_cluster_empty_tokens_stored_as_empty_bytes(self, mock_aap_auth, api_client):
+        """When no token fields are supplied the model fields should be stored as b''."""
+        api_client.post(
+            '/api/v1/clusters/',
+            data=json.dumps(_CLUSTER_PAYLOAD),
+            content_type='application/json',
+        )
+        cluster = Cluster.objects.get(address='aap.example.com')
+        assert bytes(cluster.access_token) == b''
+        assert bytes(cluster.refresh_token) == b''
+
+    def test_create_cluster_has_access_token_false_when_no_token(self, mock_aap_auth, api_client):
+        response = api_client.post(
+            '/api/v1/clusters/',
+            data=json.dumps(_CLUSTER_PAYLOAD),
+            content_type='application/json',
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data['has_access_token'] is False
+
+    # ------------------------------------------------------------------
+    # ClusterReadSerializer.get_has_access_token  (unit tests)
+    # ------------------------------------------------------------------
+
+    def test_has_access_token_false_for_empty_bytes(self, cluster):
+        # Override access_token to empty bytes without re-saving to DB
+        cluster.access_token = b''
+        serializer = ClusterReadSerializer(cluster)
+        assert serializer.data['has_access_token'] is False
+
+    def test_has_access_token_true_for_nonempty(self, cluster):
+        # cluster fixture stores a real encrypted non-empty token
+        serializer = ClusterReadSerializer(cluster)
+        assert serializer.data['has_access_token'] is True
+
+    # ------------------------------------------------------------------
+    # ClusterWriteSerializer validation
+    # ------------------------------------------------------------------
+
+    def test_cluster_write_serializer_valid_api_mode(self):
+        serializer = ClusterWriteSerializer(data=_CLUSTER_PAYLOAD)
+        assert serializer.is_valid(), serializer.errors
+
+    def test_cluster_write_serializer_valid_database_mode(self):
+        data = {
+            'protocol': 'https',
+            'address': 'aap.example.com',
+            'port': 443,
+            'aap_version': 'AAP 2.6',
+            'verify_ssl': False,
+            'sync_mode': 'database',
+            'db_host': 'db.example.com',
+            'db_port': 5432,
+            'db_name': 'awx',
+            'db_user': 'awx',
+            'db_password': 'secret',
+        }
+        serializer = ClusterWriteSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors

--- a/src/backend/tests/unit/test_jobs.py
+++ b/src/backend/tests/unit/test_jobs.py
@@ -17,6 +17,7 @@ class TestJobs:
         instance.get_job_args = None
         instance.name = "test"
         task.instance = instance
+        task.cluster = MagicMock(sync_mode='api')
         task.run_task()
         mock_update_model.assert_called_with(instance.pk, status=JobStatusChoices.FAILED, explanation="No job args provided for task test")
 
@@ -44,6 +45,7 @@ class TestJobs:
         instance.cluster = MagicMock()
         instance.cluster.base_url = "url"
         task.instance = instance
+        task.cluster = MagicMock(sync_mode='api')
         connector_instance = mock_connector.return_value
         connector_instance.check_aap_version.return_value = True
         connector_instance.sync_common.side_effect = [Exception("fail"), None]

--- a/src/backend/tests/unit/test_setup_views.py
+++ b/src/backend/tests/unit/test_setup_views.py
@@ -1,0 +1,187 @@
+import json
+from unittest import mock
+
+import pytest
+from rest_framework.test import APIClient, APIRequestFactory
+
+from backend.api.v1.setup.serializers import ClusterSetupSerializer
+from backend.apps.aap_auth.authentication import enforce_csrf
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def mock_aap_auth(superuser):
+    with mock.patch("backend.apps.aap_auth.authentication.AAPAuthentication.authenticate") as m:
+        m.return_value = superuser, None
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+class TestSetupViews:
+
+    # ------------------------------------------------------------------
+    # SetupStatusView  GET /api/v1/setup/status/
+    # ------------------------------------------------------------------
+
+    def test_setup_required_when_no_clusters(self, api_client):
+        response = api_client.get('/api/v1/setup/status/')
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {'setup_required': True}
+
+    def test_setup_not_required_when_cluster_exists(self, api_client, cluster):
+        response = api_client.get('/api/v1/setup/status/')
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {'setup_required': False}
+
+    # ------------------------------------------------------------------
+    # enforce_csrf  (unit tests — no DB needed, but class marker is fine)
+    # ------------------------------------------------------------------
+
+    def test_enforce_csrf_safe_methods_exempt(self):
+        factory = APIRequestFactory()
+        for method_name in ('get', 'head', 'options'):
+            request = getattr(factory, method_name)('/test/')
+            request.COOKIES = {}
+            request.META = {}
+            # Must not raise for safe methods
+            enforce_csrf(request)
+
+    def test_enforce_csrf_raises_when_cookie_absent_on_post(self):
+        from rest_framework.exceptions import PermissionDenied
+
+        factory = APIRequestFactory()
+        request = factory.post('/test/')
+        request.COOKIES = {}
+        request.META = {}
+
+        with pytest.raises(PermissionDenied):
+            enforce_csrf(request)
+
+    def test_enforce_csrf_raises_on_token_mismatch(self):
+        from rest_framework.exceptions import PermissionDenied
+
+        factory = APIRequestFactory()
+        request = factory.post('/test/')
+        request.COOKIES = {'csrftoken': 'correct-token'}
+        request.META['HTTP_X_XSRF_TOKEN'] = 'wrong-token'
+
+        with pytest.raises(PermissionDenied):
+            enforce_csrf(request)
+
+    def test_enforce_csrf_passes_when_tokens_match(self):
+        factory = APIRequestFactory()
+        request = factory.post('/test/')
+        request.COOKIES = {'csrftoken': 'matching-token'}
+        request.META['HTTP_X_XSRF_TOKEN'] = 'matching-token'
+
+        # Must not raise
+        enforce_csrf(request)
+
+    def test_enforce_csrf_accepts_x_csrf_token_header(self):
+        factory = APIRequestFactory()
+        request = factory.post('/test/')
+        request.COOKIES = {'csrftoken': 'shared-token'}
+        request.META['HTTP_X_CSRFTOKEN'] = 'shared-token'
+
+        # Must not raise — Django-style header also accepted
+        enforce_csrf(request)
+
+    # ------------------------------------------------------------------
+    # SetupLocalLoginView  POST /api/v1/setup/local_login/
+    # ------------------------------------------------------------------
+
+    def test_local_login_blocked_when_setup_complete(self, api_client, cluster):
+        response = api_client.post(
+            '/api/v1/setup/local_login/',
+            data=json.dumps({'username': 'anyone', 'password': 'anything'}),
+            content_type='application/json',
+        )
+        assert response.status_code == 403
+
+    def test_local_login_rejects_wrong_password(self, api_client):
+        from backend.apps.users.models import User
+
+        User.objects.create_superuser(username='admin', password='correctpass')
+        response = api_client.post(
+            '/api/v1/setup/local_login/',
+            data=json.dumps({'username': 'admin', 'password': 'wrongpass'}),
+            content_type='application/json',
+        )
+        assert response.status_code == 401
+
+    def test_local_login_succeeds_for_superuser(self, api_client):
+        from backend.apps.users.models import User
+
+        User.objects.create_superuser(username='admin', password='testpass')
+        response = api_client.post(
+            '/api/v1/setup/local_login/',
+            data=json.dumps({'username': 'admin', 'password': 'testpass'}),
+            content_type='application/json',
+        )
+        assert response.status_code == 204
+
+    # ------------------------------------------------------------------
+    # ClusterSetupSerializer
+    # ------------------------------------------------------------------
+
+    def test_cluster_write_serializer_valid_api_mode(self):
+        data = {
+            'protocol': 'https',
+            'address': 'aap.example.com',
+            'port': 443,
+            'aap_version': 'AAP 2.5',
+            'verify_ssl': True,
+            'client_id': 'my-client-id',
+            'client_secret': 'my-secret',
+            'access_token': 'my-access-token',
+            'refresh_token': 'my-refresh-token',
+            'sync_mode': 'api',
+        }
+        serializer = ClusterSetupSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+
+    def test_cluster_write_serializer_valid_database_mode(self):
+        data = {
+            'protocol': 'https',
+            'address': 'aap.example.com',
+            'port': 443,
+            'aap_version': 'AAP 2.6',
+            'verify_ssl': False,
+            'sync_mode': 'database',
+            'db_host': 'db.example.com',
+            'db_port': 5432,
+            'db_name': 'awx',
+            'db_user': 'awx',
+            'db_password': 'secret',
+        }
+        serializer = ClusterSetupSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+
+    def test_cluster_write_serializer_client_id_optional(self):
+        data = {
+            'protocol': 'https',
+            'address': 'aap.example.com',
+            'port': 5432,
+            'aap_version': 'AAP 2.4',
+            'verify_ssl': True,
+            'sync_mode': 'database',
+            'db_host': 'db.example.com',
+            'db_user': 'awx',
+        }
+        serializer = ClusterSetupSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data['client_id'] == ''

--- a/src/frontend/app/AppLayout/AppLayout.tsx
+++ b/src/frontend/app/AppLayout/AppLayout.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
-import { Button, Dropdown, DropdownItem, DropdownList, HelperText, HelperTextItem, Icon, Masthead, MastheadBrand, MastheadContent, MastheadLogo, MastheadMain, MenuToggle, MenuToggleElement, Modal, ModalBody, ModalFooter, ModalHeader, Page, Spinner, ToolbarItem } from '@patternfly/react-core';
+import { Alert, Button, Dropdown, DropdownItem, DropdownList, HelperText, HelperTextItem, Icon, Masthead, MastheadBrand, MastheadContent, MastheadLogo, MastheadMain, MenuToggle, MenuToggleElement, Modal, ModalBody, ModalFooter, ModalHeader, Page, Spinner, ToolbarItem } from '@patternfly/react-core';
 import { useAuthStore } from '@app/Store/authStore';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { RestService } from '@app/Services';
 import useFilterStore from '@app/Store/filterStore';
+import useSetupStore from '@app/Store/setupStore';
 import { CogsIcon, ExchangeAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { ClusterManagementModal } from '@app/Components/ClusterManagement';
+import useClusterStore from '@app/Store/clusterStore';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -25,6 +28,9 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const logout = useAuthStore((state) => state.logout);
   const getMyUserData = useAuthStore((state) => state.getMyUserData);
   const setReloadData = useFilterStore((state) => state.setReloadData);
+  const fetchSetupStatus = useSetupStore((state) => state.fetchSetupStatus);
+  const setupRequired = useSetupStore((state) => state.setupRequired);
+  const openClusterModal = useClusterStore((state) => state.openModal);
   const navigate = useNavigate();
   const initialized = useRef(false);
 
@@ -73,13 +79,18 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
 
   useEffect(() => {
     if (!initialized.current) {
-      getMyUserData().then((e) => {
-      }).catch((e) => {
-        if (e.status == 401) {
-          navigate('/login');
-        }
-      });
       initialized.current = true;
+      fetchSetupStatus().then((required) => {
+        if (required) {
+          navigate('/setup');
+          return;
+        }
+        getMyUserData().catch((e) => {
+          if (e?.status === 401) {
+            navigate('/login');
+          }
+        });
+      });
     }
   }, []);
 
@@ -175,6 +186,10 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
                 )}
               >
                 <DropdownList>
+                  {(myUserData?.is_superuser &&
+                    <DropdownItem onClick={() => { openClusterModal(); onSettingsDropdownSelect(); }}>
+                      Manage Clusters
+                    </DropdownItem>)}
                   {((myUserData?.is_platform_auditor || myUserData?.is_superuser) &&
                     <DropdownItem onClick={() => showResetDataModal()}>{resetModalState.title}</DropdownItem>)}
                 </DropdownList>
@@ -268,10 +283,22 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
     </Modal>
   );
 
+  const setupRequiredBanner =
+    setupRequired && isAuthenticated && !myUserData?.is_superuser ? (
+      <Alert
+        variant="warning"
+        isInline
+        title="Setup required — contact your administrator to complete the initial configuration."
+        style={{ borderRadius: 0 }}
+      />
+    ) : null;
+
   return (
     <Page mainContainerId={pageId} masthead={masthead} sidebar={null} mainComponent={'main'} className={isAuthenticated ? '' : 'dark-background'}>
+      {setupRequiredBanner}
       {children}
       {resetDataModal}
+      <ClusterManagementModal />
     </Page>
   );
 };

--- a/src/frontend/app/Components/BaseDropdown.tsx
+++ b/src/frontend/app/Components/BaseDropdown.tsx
@@ -35,7 +35,12 @@ export const BaseDropdown: React.FunctionComponent<BaseDropdownProps> = (props: 
     }
     const choicesDict = listToDict(props.options, props.idKey);
     if (props?.selectedItem && choicesDict[props.selectedItem] && props.valueKey !== undefined) {
-      setValue(choicesDict[props.selectedItem][props.valueKey].toString());
+      const valueToSet = choicesDict[props.selectedItem]?.[props.valueKey];
+      if (valueToSet !== undefined && valueToSet !== null) {
+        setValue(valueToSet.toString());
+      } else {
+        setValue(null);
+      }
     } else {
       setValue(null);
     }

--- a/src/frontend/app/Components/ClusterManagement/ClusterForm.tsx
+++ b/src/frontend/app/Components/ClusterManagement/ClusterForm.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  MenuToggle,
+  MenuToggleElement,
+  Radio,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
+import { ClusterFormData, ClusterInfo, AAPVersion } from '@app/Types/ClusterTypes';
+import useClusterStore from '@app/Store/clusterStore';
+
+interface ClusterFormProps {
+  mode: 'add' | 'edit';
+  cluster?: ClusterInfo;
+  onSave: (data: ClusterFormData) => Promise<void>;
+  onCancel: () => void;
+}
+
+const PROTOCOL_OPTIONS: Array<'http' | 'https'> = ['https', 'http'];
+const VERSION_OPTIONS: AAPVersion[] = ['AAP 2.7', 'AAP 2.6', 'AAP 2.5', 'AAP 2.4'];
+
+export const ClusterForm: React.FC<ClusterFormProps> = ({ mode, cluster, onSave, onCancel }) => {
+  const testConnection = useClusterStore((s) => s.testConnection);
+  const testDbConnection = useClusterStore((s) => s.testDbConnection);
+  const connectionTest = useClusterStore((s) => s.connectionTest);
+  const connectionError = useClusterStore((s) => s.connectionError);
+  const saving = useClusterStore((s) => s.saving);
+
+  const [syncMode, setSyncMode] = React.useState<'api' | 'database'>(cluster?.sync_mode ?? 'api');
+  const [aapVersion, setAapVersion] = React.useState<AAPVersion>(cluster?.aap_version ?? 'AAP 2.5');
+
+  // API mode fields
+  const [protocol, setProtocol] = React.useState<'http' | 'https'>(cluster?.protocol ?? 'https');
+  const [address, setAddress] = React.useState(cluster?.address ?? '');
+  const [port, setPort] = React.useState<number>(cluster?.port ?? 443);
+  const [verifySsl, setVerifySsl] = React.useState<boolean>(cluster?.verify_ssl ?? true);
+  const [clientId, setClientId] = React.useState(cluster?.client_id ?? '');
+  const [clientSecret, setClientSecret] = React.useState('');
+  const [accessToken, setAccessToken] = React.useState('');
+  const [refreshToken, setRefreshToken] = React.useState('');
+
+  // Database mode fields
+  const [dbHost, setDbHost] = React.useState(cluster?.db_host ?? '');
+  const [dbPort, setDbPort] = React.useState<number>(cluster?.db_port ?? 5432);
+  const [dbName, setDbName] = React.useState(cluster?.db_name ?? 'awx');
+  const [dbUser, setDbUser] = React.useState(cluster?.db_user ?? '');
+  const [dbPassword, setDbPassword] = React.useState('');
+
+  const [isProtocolOpen, setIsProtocolOpen] = React.useState(false);
+  const [isVersionOpen, setIsVersionOpen] = React.useState(false);
+
+  const tokenPlaceholder = mode === 'edit' ? 'Leave blank to keep existing' : '';
+  const dbPasswordPlaceholder = mode === 'edit' ? 'Leave blank to keep existing' : '';
+
+  const handleSave = async () => {
+    await onSave({
+      sync_mode: syncMode,
+      aap_version: aapVersion,
+      // API mode fields — use db_host as address surrogate in database mode
+      protocol: syncMode === 'database' ? 'https' : protocol,
+      address: syncMode === 'database' ? dbHost : address,
+      port: syncMode === 'database' ? dbPort : port,
+      verify_ssl: syncMode === 'database' ? true : verifySsl,
+      client_id: clientId,
+      client_secret: clientSecret,
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      // Database mode fields
+      db_host: dbHost,
+      db_port: dbPort,
+      db_name: dbName,
+      db_user: dbUser,
+      db_password: dbPassword,
+    });
+  };
+
+  const handleTestApi = async () => {
+    await testConnection({ protocol, address, port, access_token: accessToken, verify_ssl: verifySsl });
+  };
+
+  const handleTestDb = async () => {
+    await testDbConnection({ db_host: dbHost, db_port: dbPort, db_name: dbName, db_user: dbUser, db_password: dbPassword });
+  };
+
+  return (
+    <Form>
+      {/* Sync Mode */}
+      <FormGroup label="Sync Mode" isRequired fieldId="cluster-sync-mode">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', paddingTop: '4px' }}>
+          <Radio
+            id="form-sync-mode-api"
+            name="form-sync-mode"
+            label="API Sync"
+            description="Connect via OAuth2. Requires client credentials and access tokens."
+            isChecked={syncMode === 'api'}
+            onChange={() => setSyncMode('api')}
+          />
+          <Radio
+            id="form-sync-mode-database"
+            name="form-sync-mode"
+            label="Direct Database"
+            description="Read directly from AAP's PostgreSQL database. Requires a read-only database account."
+            isChecked={syncMode === 'database'}
+            onChange={() => setSyncMode('database')}
+          />
+        </div>
+      </FormGroup>
+
+      {/* AAP Version — shown for both modes */}
+      <FormGroup label="AAP Version" isRequired fieldId="cluster-version">
+        <Select
+          isOpen={isVersionOpen}
+          onOpenChange={(open) => setIsVersionOpen(open)}
+          onSelect={(_ev, value) => { setAapVersion(value as AAPVersion); setIsVersionOpen(false); }}
+          selected={aapVersion}
+          toggle={(ref: React.Ref<MenuToggleElement>) => (
+            <MenuToggle ref={ref} onClick={() => setIsVersionOpen(!isVersionOpen)} isExpanded={isVersionOpen} style={{ width: '160px' }}>
+              {aapVersion}
+            </MenuToggle>
+          )}
+        >
+          <SelectList>
+            {VERSION_OPTIONS.map((opt) => <SelectOption key={opt} value={opt}>{opt}</SelectOption>)}
+          </SelectList>
+        </Select>
+      </FormGroup>
+
+      {/* API mode — host/port/SSL/credentials */}
+      {syncMode === 'api' && (
+        <>
+          <FormGroup label="Protocol" isRequired fieldId="cluster-protocol">
+            <Select
+              isOpen={isProtocolOpen}
+              onOpenChange={(open) => setIsProtocolOpen(open)}
+              onSelect={(_ev, value) => { setProtocol(value as 'http' | 'https'); setIsProtocolOpen(false); }}
+              selected={protocol}
+              toggle={(ref: React.Ref<MenuToggleElement>) => (
+                <MenuToggle ref={ref} onClick={() => setIsProtocolOpen(!isProtocolOpen)} isExpanded={isProtocolOpen} style={{ width: '160px' }}>
+                  {protocol}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {PROTOCOL_OPTIONS.map((opt) => <SelectOption key={opt} value={opt}>{opt}</SelectOption>)}
+              </SelectList>
+            </Select>
+          </FormGroup>
+
+          <FormGroup label="Host" isRequired fieldId="cluster-address">
+            <TextInput id="cluster-address" value={address} onChange={(_ev, val) => setAddress(val)} placeholder="aap.example.com" isRequired />
+          </FormGroup>
+
+          <FormGroup label="Port" isRequired fieldId="cluster-port">
+            <TextInput id="cluster-port" type="number" value={String(port)} onChange={(_ev, val) => setPort(Number(val))} isRequired />
+          </FormGroup>
+
+          <FormGroup fieldId="cluster-verify-ssl">
+            <Switch id="cluster-verify-ssl" label="Verify SSL" isChecked={verifySsl} onChange={(_ev, checked) => setVerifySsl(checked)} />
+          </FormGroup>
+
+          <FormGroup label="Client ID" isRequired fieldId="cluster-client-id">
+            <TextInput id="cluster-client-id" value={clientId} onChange={(_ev, val) => setClientId(val)} isRequired />
+          </FormGroup>
+
+          <FormGroup label="Client Secret" fieldId="cluster-client-secret">
+            <TextInput id="cluster-client-secret" type="password" value={clientSecret} onChange={(_ev, val) => setClientSecret(val)} placeholder={tokenPlaceholder} />
+          </FormGroup>
+
+          <FormGroup label="Access Token" fieldId="cluster-access-token">
+            <TextInput id="cluster-access-token" type="password" value={accessToken} onChange={(_ev, val) => setAccessToken(val)} placeholder={tokenPlaceholder} />
+          </FormGroup>
+
+          <FormGroup label="Refresh Token" fieldId="cluster-refresh-token">
+            <TextInput id="cluster-refresh-token" type="password" value={refreshToken} onChange={(_ev, val) => setRefreshToken(val)} placeholder={tokenPlaceholder} />
+          </FormGroup>
+
+          {connectionTest === 'success' && <Alert variant="success" isInline title="Connection successful" />}
+          {connectionTest === 'failed' && <Alert variant="danger" isInline title={`Connection failed${connectionError ? `: ${connectionError}` : ''}`} />}
+
+          <ActionGroup>
+            <Button variant="secondary" onClick={handleTestApi} isDisabled={connectionTest === 'testing' || saving} icon={connectionTest === 'testing' ? <Spinner size="sm" /> : undefined}>
+              {connectionTest === 'testing' ? 'Testing…' : 'Test Connection'}
+            </Button>
+          </ActionGroup>
+        </>
+      )}
+
+      {/* Database mode — only DB credentials */}
+      {syncMode === 'database' && (
+        <>
+          <FormGroup label="DB Host" isRequired fieldId="db-host">
+            <TextInput id="db-host" value={dbHost} onChange={(_ev, val) => setDbHost(val.replace(/^https?:\/\//i, ''))} placeholder="44.201.211.61" isRequired />
+            <FormHelperText><HelperText><HelperTextItem>IP address or hostname only — no <code>http://</code> or <code>https://</code></HelperTextItem></HelperText></FormHelperText>
+          </FormGroup>
+
+          <FormGroup label="DB Port" isRequired fieldId="db-port">
+            <TextInput id="db-port" type="number" value={String(dbPort)} onChange={(_ev, val) => setDbPort(parseInt(val, 10) || 5432)} isRequired style={{ maxWidth: '120px' }} />
+          </FormGroup>
+
+          <FormGroup label="Database Name" isRequired fieldId="db-name">
+            <TextInput id="db-name" value={dbName} onChange={(_ev, val) => setDbName(val)} placeholder="awx" isRequired />
+          </FormGroup>
+
+          <FormGroup label="DB User" isRequired fieldId="db-user">
+            <TextInput id="db-user" value={dbUser} onChange={(_ev, val) => setDbUser(val)} isRequired />
+          </FormGroup>
+
+          <FormGroup label="DB Password" fieldId="db-password">
+            <TextInput id="db-password" type="password" value={dbPassword} onChange={(_ev, val) => setDbPassword(val)} placeholder={dbPasswordPlaceholder} />
+          </FormGroup>
+
+          {connectionTest === 'success' && <Alert variant="success" isInline title="Database connection successful" />}
+          {connectionTest === 'failed' && <Alert variant="danger" isInline title={`Connection failed${connectionError ? `: ${connectionError}` : ''}`} />}
+
+          <ActionGroup>
+            <Button variant="secondary" onClick={handleTestDb} isDisabled={connectionTest === 'testing' || saving || !dbHost || !dbUser} icon={connectionTest === 'testing' ? <Spinner size="sm" /> : undefined}>
+              {connectionTest === 'testing' ? 'Testing…' : 'Test Connection'}
+            </Button>
+          </ActionGroup>
+        </>
+      )}
+
+      <ActionGroup>
+        <Button variant="primary" onClick={handleSave} isDisabled={saving || connectionTest === 'testing'} icon={saving ? <Spinner size="sm" /> : undefined}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+        <Button variant="link" onClick={onCancel} isDisabled={saving}>Cancel</Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+export default ClusterForm;

--- a/src/frontend/app/Components/ClusterManagement/ClusterList.tsx
+++ b/src/frontend/app/Components/ClusterManagement/ClusterList.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Label,
+  Spinner,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { LockIcon, SyncAltIcon } from '@patternfly/react-icons';
+import useClusterStore from '@app/Store/clusterStore';
+import { ClusterInfo } from '@app/Types/ClusterTypes';
+
+interface ClusterListProps {
+  onAddCluster: () => void;
+}
+
+function formatLastSynced(value: string | null): string {
+  if (!value) {
+    return 'Never';
+  }
+  try {
+    const date = new Date(value);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 30) return `${diffDays}d ago`;
+    return date.toLocaleDateString();
+  } catch {
+    return value;
+  }
+}
+
+const ClusterRow: React.FC<{ cluster: ClusterInfo }> = ({ cluster }) => {
+  const syncCluster = useClusterStore((s) => s.syncCluster);
+  const deleteCluster = useClusterStore((s) => s.deleteCluster);
+  const startEdit = useClusterStore((s) => s.startEdit);
+  const syncing = useClusterStore((s) => s.syncing);
+  const isSyncing = syncing.includes(cluster.id);
+
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
+
+  const address = `${cluster.protocol}://${cluster.address}:${cluster.port}`;
+
+  const handleDelete = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    try {
+      await deleteCluster(cluster.id);
+    } catch {
+      setDeleteError('Failed to delete cluster');
+      setConfirmDelete(false);
+    }
+  };
+
+  const handleSync = async () => {
+    await syncCluster(cluster.id);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        padding: '12px 0',
+        borderBottom: '1px solid var(--pf-v6-global--BorderColor--100)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ flex: '1 1 220px', minWidth: 0 }}>
+        <span style={{ fontWeight: 500, wordBreak: 'break-all' }}>{address}</span>
+      </div>
+
+      <div style={{ flex: '0 0 auto' }}>
+        <Label color="blue" isCompact>
+          {cluster.aap_version}
+        </Label>
+      </div>
+
+      <div style={{ flex: '0 0 auto' }}>
+        {cluster.verify_ssl ? (
+          <Label color="green" icon={<LockIcon />} isCompact>
+            SSL verified
+          </Label>
+        ) : (
+          <Label color="orange" isCompact>
+            SSL unverified
+          </Label>
+        )}
+      </div>
+
+      <div style={{ flex: '0 0 120px', color: 'var(--pf-v6-global--Color--200)', fontSize: '0.875rem' }}>
+        {formatLastSynced(cluster.last_synced)}
+      </div>
+
+      <div style={{ flex: '0 0 auto', display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <Button variant="secondary" size="sm" onClick={() => startEdit(cluster)}>
+          Edit
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleSync}
+          isDisabled={isSyncing}
+          icon={isSyncing ? <Spinner size="sm" /> : <SyncAltIcon />}
+        >
+          {isSyncing ? 'Syncing…' : 'Sync Now'}
+        </Button>
+        {confirmDelete ? (
+          <>
+            <Button variant="danger" size="sm" onClick={handleDelete}>
+              Confirm Delete
+            </Button>
+            <Button variant="link" size="sm" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button variant="danger" size="sm" onClick={handleDelete}>
+            Delete
+          </Button>
+        )}
+      </div>
+
+      {deleteError && (
+        <div style={{ width: '100%' }}>
+          <Alert variant="danger" isInline isPlain title={deleteError} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const ClusterList: React.FC<ClusterListProps> = ({ onAddCluster }) => {
+  const clusters = useClusterStore((s) => s.clusters);
+  const error = useClusterStore((s) => s.error);
+
+  return (
+    <div>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem align={{ default: 'alignEnd' }}>
+            <Button variant="primary" onClick={onAddCluster}>
+              Add Cluster
+            </Button>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      {error && <Alert variant="danger" isInline title={error} style={{ marginBottom: '16px' }} />}
+
+      {clusters.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: '32px', color: 'var(--pf-v6-global--Color--200)' }}>
+          No clusters configured. Click &quot;Add Cluster&quot; to get started.
+        </div>
+      ) : (
+        <div>
+          {clusters.map((cluster) => (
+            <ClusterRow key={cluster.id} cluster={cluster} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClusterList;

--- a/src/frontend/app/Components/ClusterManagement/ClusterManagementModal.tsx
+++ b/src/frontend/app/Components/ClusterManagement/ClusterManagementModal.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Modal, ModalBody, ModalHeader, Spinner } from '@patternfly/react-core';
+import useClusterStore from '@app/Store/clusterStore';
+import { ClusterList } from './ClusterList';
+import { ClusterForm } from './ClusterForm';
+
+export const ClusterManagementModal: React.FC = () => {
+  const isModalOpen = useClusterStore((s) => s.isModalOpen);
+  const formMode = useClusterStore((s) => s.formMode);
+  const editingCluster = useClusterStore((s) => s.editingCluster);
+  const clusters = useClusterStore((s) => s.clusters);
+  const loading = useClusterStore((s) => s.loading);
+  const closeModal = useClusterStore((s) => s.closeModal);
+  const startAdd = useClusterStore((s) => s.startAdd);
+  const saveCluster = useClusterStore((s) => s.saveCluster);
+  const backToList = useClusterStore((s) => s.backToList);
+
+  const title =
+    formMode === 'list'
+      ? 'Cluster Management'
+      : formMode === 'add'
+        ? 'Add Cluster'
+        : 'Edit Cluster';
+
+  return (
+    <Modal
+      isOpen={isModalOpen}
+      onClose={closeModal}
+      variant="large"
+      aria-label="Cluster management"
+    >
+      <ModalHeader title={title} />
+      <ModalBody>
+        {loading && clusters.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '32px' }}>
+            <Spinner aria-label="Loading clusters" />
+          </div>
+        ) : formMode === 'list' ? (
+          <ClusterList onAddCluster={() => startAdd()} />
+        ) : formMode === 'add' ? (
+          <ClusterForm
+            mode="add"
+            onSave={saveCluster}
+            onCancel={backToList}
+          />
+        ) : (
+          <ClusterForm
+            mode="edit"
+            cluster={editingCluster ?? undefined}
+            onSave={saveCluster}
+            onCancel={backToList}
+          />
+        )}
+      </ModalBody>
+    </Modal>
+  );
+};
+
+export default ClusterManagementModal;

--- a/src/frontend/app/Components/ClusterManagement/index.ts
+++ b/src/frontend/app/Components/ClusterManagement/index.ts
@@ -1,0 +1,1 @@
+export { default as ClusterManagementModal } from './ClusterManagementModal';

--- a/src/frontend/app/Components/DateRangePicker.tsx
+++ b/src/frontend/app/Components/DateRangePicker.tsx
@@ -14,8 +14,10 @@ export const DateRangePicker: React.FunctionComponent<DateRangePickerProps> = (p
       setDateChoices(dateChoices);
       if (!props.selectedRange) {
         const index = dateChoices.findIndex((v) => v.key === 'month_to_date');
-        const range = index > -1 ? dateChoices[index].key : dateChoices[0].key;
-        props.onChange(range.toString(), props.dateFrom, props.dateTo ?? new Date());
+        const range = index > -1 ? dateChoices[index]?.key : dateChoices[0]?.key;
+        if (range) {
+          props.onChange(range.toString(), props.dateFrom, props.dateTo ?? new Date());
+        }
       }
     }
   }, [dateChoices]);

--- a/src/frontend/app/Components/Login.tsx
+++ b/src/frontend/app/Components/Login.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Alert, Button, LoginPage, Spinner } from '@patternfly/react-core';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  LoginPage,
+  Spinner,
+  TextInput,
+} from '@patternfly/react-core';
 import { useAuthStore } from '@app/Store/authStore';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSearchParams } from 'react-router-dom';
 import { AppSettings } from '@app/Types/AuthTypes';
+import api from '@app/client/apiClient';
 import logo from '../../assets/images/logo.svg';
 
 
@@ -12,6 +22,7 @@ export const Login: React.FunctionComponent = () => {
   const [searchParams] = useSearchParams();
   const fetchAppSettings = useAuthStore((state) => state.fetchAppSettings);
   const authorizeUser = useAuthStore((state) => state.authorizeUser);
+  const getMyUserData = useAuthStore((state) => state.getMyUserData);
   const appSettings: AppSettings | null = useAuthStore((state) => state.appSettings);
   const error = useAuthStore((state) => state.error);
   const hasFetched = useRef(false);
@@ -19,8 +30,14 @@ export const Login: React.FunctionComponent = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const defaultErrorMessage = 'Something went wrong during authorization. Please contact your system administrator.';
+  // Dev login form state (shown when AAP settings fail to load)
+  const [devMode, setDevMode] = useState(false);
+  const [devUsername, setDevUsername] = useState('');
+  const [devPassword, setDevPassword] = useState('');
+  const [devError, setDevError] = useState<string | null>(null);
+  const [devLoading, setDevLoading] = useState(false);
 
+  const defaultErrorMessage = 'Something went wrong during authorization. Please contact your system administrator.';
   const [errorMessage, seterrorMessage] = useState('false');
 
   const loginWithAAP = () => {
@@ -38,11 +55,35 @@ export const Login: React.FunctionComponent = () => {
     });
   };
 
+  const handleDevLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setDevLoading(true);
+    setDevError(null);
+    try {
+      await api.post('/api/v1/aap_auth/dev_login/', { username: devUsername, password: devPassword });
+      await getMyUserData();
+      navigate('/');
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Login failed';
+      setDevError(msg);
+    } finally {
+      setDevLoading(false);
+    }
+  };
+
   useEffect(() => {
     if (!hasFetched.current) {
-      fetchAppSettings().catch(() => {
-        seterrorMessage(defaultErrorMessage);
-      });
+      fetchAppSettings()
+        .then(() => {
+          // If settings loaded but url/client_id are blank, AAP isn't configured
+          const s = useAuthStore.getState().appSettings;
+          if (!s?.url || !s?.client_id) {
+            setDevMode(true);
+          }
+        })
+        .catch(() => {
+          setDevMode(true);  // AAP not configured or unreachable
+        });
       hasFetched.current = true;
     }
 
@@ -58,6 +99,54 @@ export const Login: React.FunctionComponent = () => {
       initialized.current = true;
     }
   }, []);
+
+  // Dev/local login form — shown when AAP OAuth isn't configured
+  if (devMode) {
+    return (
+      <LoginPage
+        brandImgSrc={logo}
+        brandImgAlt="Ansible Automation Platform"
+        loginTitle="Sign in to your account"
+        loginSubtitle="AAP OAuth is not configured — signing in with a local account"
+      >
+        {devError && (
+          <Alert variant="danger" title={devError} isInline style={{ marginBottom: '16px' }} />
+        )}
+        <Form onSubmit={handleDevLogin}>
+          <FormGroup label="Username" fieldId="dev-username" isRequired>
+            <TextInput
+              id="dev-username"
+              value={devUsername}
+              onChange={(_e, v) => setDevUsername(v)}
+              isRequired
+              autoComplete="username"
+              autoFocus
+            />
+          </FormGroup>
+          <FormGroup label="Password" fieldId="dev-password" isRequired>
+            <TextInput
+              id="dev-password"
+              type="password"
+              value={devPassword}
+              onChange={(_e, v) => setDevPassword(v)}
+              isRequired
+              autoComplete="current-password"
+            />
+          </FormGroup>
+          <ActionGroup>
+            <Button
+              variant="primary"
+              type="submit"
+              isDisabled={devLoading || !devUsername || !devPassword}
+              isBlock
+            >
+              {devLoading ? <><Spinner size="sm" />&nbsp;Signing in…</> : 'Sign in'}
+            </Button>
+          </ActionGroup>
+        </Form>
+      </LoginPage>
+    );
+  }
 
   return (
     <>

--- a/src/frontend/app/Setup/LocalLoginForm.tsx
+++ b/src/frontend/app/Setup/LocalLoginForm.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  LoginPage,
+  Spinner,
+  TextInput,
+} from '@patternfly/react-core';
+import logo from '../../assets/images/logo.svg';
+import useSetupStore from '@app/Store/setupStore';
+
+interface LocalLoginFormProps {
+  onAuthenticated: () => void;
+}
+
+const LocalLoginForm: React.FC<LocalLoginFormProps> = ({ onAuthenticated }) => {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const localLogin = useSetupStore((s) => s.localLogin);
+  const localLoginError = useSetupStore((s) => s.localLoginError);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await localLogin(username, password);
+      onAuthenticated();
+    } catch {
+      // error is set in store
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <LoginPage
+      brandImgSrc={logo}
+      brandImgAlt="Ansible Automation Platform"
+      loginTitle="Sign in to continue setup"
+      loginSubtitle="Use your administrator account to configure the dashboard"
+    >
+      {localLoginError && (
+        <Alert
+          variant="danger"
+          title={localLoginError}
+          isInline
+          style={{ marginBottom: '16px' }}
+        />
+      )}
+      <Form onSubmit={handleSubmit}>
+        <FormGroup label="Username" fieldId="setup-username" isRequired>
+          <TextInput
+            id="setup-username"
+            value={username}
+            onChange={(_e, v) => setUsername(v)}
+            isRequired
+            autoComplete="username"
+            autoFocus
+          />
+        </FormGroup>
+        <FormGroup label="Password" fieldId="setup-password" isRequired>
+          <TextInput
+            id="setup-password"
+            type="password"
+            value={password}
+            onChange={(_e, v) => setPassword(v)}
+            isRequired
+            autoComplete="current-password"
+          />
+        </FormGroup>
+        <ActionGroup>
+          <Button
+            variant="primary"
+            type="submit"
+            isDisabled={loading || !username || !password}
+            isBlock
+          >
+            {loading ? (
+              <>
+                <Spinner size="sm" aria-label="Signing in" />
+                &nbsp; Signing in…
+              </>
+            ) : (
+              'Sign in'
+            )}
+          </Button>
+        </ActionGroup>
+      </Form>
+    </LoginPage>
+  );
+};
+
+export default LocalLoginForm;

--- a/src/frontend/app/Setup/SetupWizard.tsx
+++ b/src/frontend/app/Setup/SetupWizard.tsx
@@ -1,0 +1,258 @@
+import * as React from 'react';
+import { Alert, Spinner } from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+import logo from '../../assets/images/logo.svg';
+import LocalLoginForm from './LocalLoginForm';
+import StepWelcome from './StepWelcome';
+import StepCluster from './StepCluster';
+import StepTokens from './StepTokens';
+import StepDatabase from './StepDatabase';
+import StepSync from './StepSync';
+import StepInfra from './StepInfra';
+import StepCosts from './StepCosts';
+import StepReview from './StepReview';
+import StepProgress from './StepProgress';
+
+type Step = 'welcome' | 'cluster' | 'tokens' | 'database' | 'sync' | 'infra' | 'costs' | 'review' | 'progress';
+
+const STEP_LABELS: Record<Step, string> = {
+  welcome: 'Welcome',
+  cluster: 'Cluster Connection',
+  tokens: 'OAuth Tokens',
+  database: 'Database Connection',
+  sync: 'Sync Range',
+  infra: 'Infrastructure',
+  costs: 'Cost Settings',
+  review: 'Review & Apply',
+  progress: 'Progress',
+};
+
+interface SidebarProps {
+  current: Step;
+  username: string;
+  steps: Step[];
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ current, username, steps }) => {
+  const stepIndex = (s: Step) => steps.indexOf(s);
+
+  return (
+    <div style={{
+      width: '260px',
+      minWidth: '260px',
+      background: 'var(--pf-v6-global--BackgroundColor--dark-100)',
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+    }}>
+      {/* Header */}
+      <div style={{ padding: '28px 24px 24px', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+        <img src={logo} alt="Ansible Automation Platform" style={{ height: '36px', marginBottom: '16px', display: 'block' }} />
+        <div style={{ color: '#fff', fontWeight: 600, fontSize: '1rem', lineHeight: 1.3 }}>
+          Automation Dashboard
+        </div>
+        <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '0.8rem', marginTop: '2px' }}>
+          Setup Wizard
+        </div>
+      </div>
+
+      {/* Steps */}
+      <nav style={{ flex: 1, padding: '16px 12px', overflowY: 'auto' }}>
+        {steps.map((s, idx) => {
+          const ci = stepIndex(current);
+          const done = idx < ci;
+          const active = s === current;
+          const future = idx > ci;
+
+          return (
+            <div
+              key={s}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                padding: '9px 12px',
+                borderRadius: '6px',
+                marginBottom: '2px',
+                background: active ? 'rgba(255,255,255,0.12)' : 'transparent',
+                transition: 'background 0.15s',
+              }}
+            >
+              <span style={{
+                width: '22px',
+                height: '22px',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '0.7rem',
+                fontWeight: 700,
+                flexShrink: 0,
+                background: done
+                  ? 'var(--pf-v6-global--success-color--100)'
+                  : active
+                    ? 'var(--pf-v6-global--primary-color--100)'
+                    : 'rgba(255,255,255,0.15)',
+                color: '#fff',
+              }}>
+                {done ? '✓' : idx + 1}
+              </span>
+              <span style={{
+                fontSize: '0.85rem',
+                fontWeight: active ? 600 : 400,
+                color: active
+                  ? '#fff'
+                  : done
+                    ? 'rgba(255,255,255,0.8)'
+                    : future
+                      ? 'rgba(255,255,255,0.4)'
+                      : 'rgba(255,255,255,0.6)',
+                lineHeight: 1.3,
+              }}>
+                {STEP_LABELS[s]}
+              </span>
+            </div>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div style={{
+        padding: '16px 24px',
+        borderTop: '1px solid rgba(255,255,255,0.1)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+      }}>
+        <div style={{
+          width: '28px', height: '28px',
+          borderRadius: '50%',
+          background: 'rgba(255,255,255,0.15)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontSize: '0.75rem', fontWeight: 600,
+        }}>
+          {username.slice(0, 1).toUpperCase()}
+        </div>
+        <div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '0.8rem', fontWeight: 500 }}>{username}</div>
+          <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.7rem' }}>Administrator</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SetupWizard: React.FC = () => {
+  const fetchSetupMe = useSetupStore((s) => s.fetchSetupMe);
+  const setupMe = useSetupStore((s) => s.setupMe);
+  const configure = useSetupStore((s) => s.configure);
+  const configureStatus = useSetupStore((s) => s.configureStatus);
+  const cluster = useSetupStore((s) => s.cluster);
+
+  const [loading, setLoading] = React.useState(true);
+  const [step, setStep] = React.useState<Step>('welcome');
+
+  // Dynamic step list based on sync_mode
+  const steps = React.useMemo<Step[]>(() => {
+    const base: Step[] = ['welcome', 'cluster'];
+    if (cluster.sync_mode === 'database') {
+      base.push('database');
+    } else {
+      base.push('tokens');
+    }
+    return [...base, 'sync', 'infra', 'costs', 'review', 'progress'];
+  }, [cluster.sync_mode]);
+
+  const stepIndex = (s: Step) => steps.indexOf(s);
+
+  React.useEffect(() => {
+    fetchSetupMe().finally(() => setLoading(false));
+  }, []);
+
+  // If the current step is no longer in the dynamic list (e.g. sync_mode changed),
+  // fall back to the previous valid step.
+  React.useEffect(() => {
+    if (stepIndex(step) === -1) {
+      setStep('cluster');
+    }
+  }, [steps]);
+
+  const next = () => {
+    const idx = stepIndex(step);
+    if (idx < steps.length - 1) setStep(steps[idx + 1]);
+  };
+
+  const back = () => {
+    const idx = stepIndex(step);
+    if (idx > 0) setStep(steps[idx - 1]);
+  };
+
+  const handleApply = async () => {
+    try {
+      await configure();
+      setStep('progress');
+    } catch {
+      // error shown in StepReview
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <Spinner aria-label="Loading" />
+      </div>
+    );
+  }
+
+  if (!setupMe?.authenticated || !setupMe?.is_superuser) {
+    return <LocalLoginForm onAuthenticated={() => fetchSetupMe()} />;
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+      <Sidebar current={step} username={setupMe.username ?? 'admin'} steps={steps} />
+
+      {/* Content area */}
+      <div style={{
+        flex: 1,
+        overflowY: 'auto',
+        background: 'var(--pf-v6-global--BackgroundColor--100)',
+        display: 'flex',
+        flexDirection: 'column',
+      }}>
+        {/* Content header bar */}
+        <div style={{
+          padding: '20px 48px',
+          borderBottom: '1px solid var(--pf-v6-global--BorderColor--100)',
+          background: 'var(--pf-v6-global--BackgroundColor--100)',
+        }}>
+          <div style={{ fontSize: '0.75rem', color: 'var(--pf-v6-global--Color--200)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '2px' }}>
+            Step {stepIndex(step) + 1} of {steps.length}
+          </div>
+          <div style={{ fontWeight: 600, fontSize: '1.1rem', color: 'var(--pf-v6-global--Color--100)' }}>
+            {STEP_LABELS[step]}
+          </div>
+        </div>
+
+        {/* Step content */}
+        <div style={{ flex: 1, padding: '40px 48px', maxWidth: '680px' }}>
+          {configureStatus === 'success' && step !== 'progress' && (
+            <Alert variant="success" title="Configuration saved" isInline style={{ marginBottom: '24px' }} />
+          )}
+
+          {step === 'welcome' && <StepWelcome onNext={next} />}
+          {step === 'cluster' && <StepCluster onNext={next} onBack={back} />}
+          {step === 'tokens' && <StepTokens onNext={next} onBack={back} />}
+          {step === 'database' && <StepDatabase onNext={next} onBack={back} />}
+          {step === 'sync' && <StepSync onNext={next} onBack={back} />}
+          {step === 'infra' && <StepInfra onNext={next} onBack={back} />}
+          {step === 'costs' && <StepCosts onNext={next} onBack={back} />}
+          {step === 'review' && <StepReview onApply={handleApply} onBack={back} />}
+          {step === 'progress' && <StepProgress />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetupWizard;

--- a/src/frontend/app/Setup/StepCluster.tsx
+++ b/src/frontend/app/Setup/StepCluster.tsx
@@ -1,0 +1,217 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Radio,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  Switch,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+import { AAPVersion } from '@app/Types/SetupTypes';
+
+interface StepClusterProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const AAP_VERSIONS: AAPVersion[] = ['AAP 2.7', 'AAP 2.6', 'AAP 2.5', 'AAP 2.4'];
+
+const StepCluster: React.FC<StepClusterProps> = ({ onNext, onBack }) => {
+  const cluster = useSetupStore((s) => s.cluster);
+  const setCluster = useSetupStore((s) => s.setCluster);
+  const testConnection = useSetupStore((s) => s.testConnection);
+  const connectionTest = useSetupStore((s) => s.connectionTest);
+  const connectionError = useSetupStore((s) => s.connectionError);
+
+  const [versionOpen, setVersionOpen] = React.useState(false);
+  const [protocolOpen, setProtocolOpen] = React.useState(false);
+
+  const syncMode = cluster.sync_mode ?? 'api';
+
+  const isValid =
+    cluster.address.trim() !== '' &&
+    (syncMode === 'database' || (cluster.client_id.trim() !== '' && cluster.client_secret.trim() !== ''));
+
+  const handleTest = async () => {
+    await testConnection();
+  };
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        AAP Cluster Connection
+      </Title>
+      <p style={{ marginBottom: '24px' }}>
+        Enter the connection details for your Ansible Automation Platform Controller.
+      </p>
+
+      <Form style={{ maxWidth: '560px' }}>
+        <FormGroup label="How will this cluster sync data?" fieldId="cluster-sync-mode" isRequired>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', paddingTop: '4px' }}>
+            <Radio
+              id="sync-mode-api"
+              name="sync-mode"
+              label="API Sync"
+              description="Connect via OAuth2. Requires client credentials and access tokens."
+              isChecked={syncMode === 'api'}
+              onChange={() => setCluster({ sync_mode: 'api' })}
+            />
+            <Radio
+              id="sync-mode-database"
+              name="sync-mode"
+              label="Direct Database"
+              description="Read directly from AAP's PostgreSQL database. Requires a read-only database account."
+              isChecked={syncMode === 'database'}
+              onChange={() => setCluster({ sync_mode: 'database' })}
+            />
+          </div>
+        </FormGroup>
+
+        <FormGroup label="Protocol" fieldId="cluster-protocol" isRequired>
+          <Select
+            id="cluster-protocol"
+            isOpen={protocolOpen}
+            onOpenChange={setProtocolOpen}
+            selected={cluster.protocol}
+            onSelect={(_e, val) => { setCluster({ protocol: val as 'http' | 'https' }); setProtocolOpen(false); }}
+            toggle={(ref: React.Ref<MenuToggleElement>) => (
+              <MenuToggle ref={ref} onClick={() => setProtocolOpen(!protocolOpen)} isExpanded={protocolOpen}>
+                {cluster.protocol}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              <SelectOption value="https">https</SelectOption>
+              <SelectOption value="http">http</SelectOption>
+            </SelectList>
+          </Select>
+        </FormGroup>
+
+        <FormGroup label="AAP Host" fieldId="cluster-address" isRequired>
+          <TextInput
+            id="cluster-address"
+            value={cluster.address}
+            onChange={(_e, v) => setCluster({ address: v })}
+            placeholder="my-aap.example.com"
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>Hostname or IP address — do not include protocol or port</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <FormGroup label="Port" fieldId="cluster-port" isRequired>
+          <TextInput
+            id="cluster-port"
+            type="number"
+            value={String(cluster.port)}
+            onChange={(_e, v) => setCluster({ port: parseInt(v, 10) || 443 })}
+            isRequired
+          />
+        </FormGroup>
+
+        <FormGroup label="AAP Version" fieldId="cluster-version" isRequired>
+          <Select
+            id="cluster-version"
+            isOpen={versionOpen}
+            onOpenChange={setVersionOpen}
+            selected={cluster.aap_version}
+            onSelect={(_e, val) => { setCluster({ aap_version: val as AAPVersion }); setVersionOpen(false); }}
+            toggle={(ref: React.Ref<MenuToggleElement>) => (
+              <MenuToggle ref={ref} onClick={() => setVersionOpen(!versionOpen)} isExpanded={versionOpen}>
+                {cluster.aap_version}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              {AAP_VERSIONS.map((v) => <SelectOption key={v} value={v}>{v}</SelectOption>)}
+            </SelectList>
+          </Select>
+        </FormGroup>
+
+        {syncMode === 'api' && (
+          <>
+            <FormGroup label="Client ID" fieldId="cluster-client-id" isRequired>
+              <TextInput
+                id="cluster-client-id"
+                value={cluster.client_id}
+                onChange={(_e, v) => setCluster({ client_id: v })}
+                isRequired
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>From the OAuth2 application you created in AAP Controller</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+
+            <FormGroup label="Client Secret" fieldId="cluster-client-secret" isRequired>
+              <TextInput
+                id="cluster-client-secret"
+                type="password"
+                value={cluster.client_secret}
+                onChange={(_e, v) => setCluster({ client_secret: v })}
+                isRequired
+              />
+            </FormGroup>
+          </>
+        )}
+
+        <FormGroup label="Verify SSL" fieldId="cluster-verify-ssl">
+          <Switch
+            id="cluster-verify-ssl"
+            label={cluster.verify_ssl ? 'Verify SSL certificate' : 'Skip SSL verification'}
+            isChecked={cluster.verify_ssl}
+            onChange={(_e, checked) => setCluster({ verify_ssl: checked })}
+          />
+        </FormGroup>
+
+        {syncMode === 'api' && (
+          <>
+            {connectionError && (
+              <Alert variant="danger" title={connectionError} isInline />
+            )}
+            {connectionTest === 'success' && (
+              <Alert variant="success" title="Connection successful" isInline />
+            )}
+
+            <ActionGroup>
+              <Button
+                variant="secondary"
+                onClick={handleTest}
+                isDisabled={!cluster.address || !cluster.access_token || connectionTest === 'testing'}
+              >
+                {connectionTest === 'testing' ? <><Spinner size="sm" /> Testing...</> : 'Test Connection'}
+              </Button>
+            </ActionGroup>
+          </>
+        )}
+
+        <ActionGroup>
+          <Button variant="primary" onClick={onNext} isDisabled={!isValid}>
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepCluster;

--- a/src/frontend/app/Setup/StepCosts.tsx
+++ b/src/frontend/app/Setup/StepCosts.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepCostsProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const StepCosts: React.FC<StepCostsProps> = ({ onNext, onBack }) => {
+  const costs = useSetupStore((s) => s.costs);
+  const setCosts = useSetupStore((s) => s.setCosts);
+
+  const isValid =
+    costs.monthly_subscription_cost > 0 &&
+    costs.engineer_avg_hourly_rate > 0;
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        Cost Settings
+      </Title>
+      <p style={{ marginBottom: '24px' }}>
+        These values are used to calculate automation savings in the dashboard reports. You can change
+        them later from the dashboard.
+      </p>
+
+      <Form style={{ maxWidth: '420px' }}>
+        <FormGroup label="Monthly AAP Subscription Cost" fieldId="cost-monthly" isRequired>
+          <TextInput
+            id="cost-monthly"
+            type="number"
+            value={String(costs.monthly_subscription_cost)}
+            onChange={(_e, v) => setCosts({ monthly_subscription_cost: parseFloat(v) || 0 })}
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Total monthly cost of running AAP — includes license, labor, and infrastructure
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <FormGroup label="Engineer Average Hourly Rate" fieldId="cost-hourly" isRequired>
+          <TextInput
+            id="cost-hourly"
+            type="number"
+            value={String(costs.engineer_avg_hourly_rate)}
+            onChange={(_e, v) => setCosts({ engineer_avg_hourly_rate: parseFloat(v) || 0 })}
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Average hourly rate for engineers performing manual tasks (used to calculate manual vs automated cost)
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <ActionGroup>
+          <Button variant="primary" onClick={onNext} isDisabled={!isValid}>
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepCosts;

--- a/src/frontend/app/Setup/StepDatabase.tsx
+++ b/src/frontend/app/Setup/StepDatabase.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Spinner,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import api from '@app/client/apiClient';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepDatabaseProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const StepDatabase: React.FC<StepDatabaseProps> = ({ onNext, onBack }) => {
+  const cluster = useSetupStore((s) => s.cluster);
+  const setCluster = useSetupStore((s) => s.setCluster);
+
+  const [testing, setTesting] = React.useState(false);
+  const [testResult, setTestResult] = React.useState<'idle' | 'success' | 'failed'>('idle');
+  const [testError, setTestError] = React.useState<string | null>(null);
+
+  // Pre-fill db_host from cluster address if blank
+  React.useEffect(() => {
+    if (!cluster.db_host && cluster.address) {
+      setCluster({ db_host: cluster.address });
+    }
+  }, []);
+
+  const isValid =
+    cluster.db_host.trim() !== '' &&
+    cluster.db_user.trim() !== '' &&
+    cluster.db_password.trim() !== '' &&
+    cluster.db_name.trim() !== '';
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult('idle');
+    setTestError(null);
+    try {
+      const res = await api.post<{ success: boolean; error: string | null }>('/api/v1/setup/test_connection/', {
+        sync_mode: 'database',
+        db_host: cluster.db_host,
+        db_port: cluster.db_port,
+        db_name: cluster.db_name,
+        db_user: cluster.db_user,
+        db_password: cluster.db_password,
+      });
+      setTestResult(res.data.success ? 'success' : 'failed');
+      setTestError(res.data.error);
+    } catch {
+      setTestResult('failed');
+      setTestError('Database connection test failed');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        Database Connection
+      </Title>
+      <p style={{ marginBottom: '16px' }}>
+        Provide read-only credentials for AAP&apos;s PostgreSQL database.
+      </p>
+
+      <Alert
+        variant="info"
+        title="Read-only database account required"
+        isInline
+        style={{ marginBottom: '24px' }}
+      >
+        Create a read-only PostgreSQL user in AAP&apos;s database. The user needs SELECT permission on AAP tables.
+        Example: <code>GRANT SELECT ON ALL TABLES IN SCHEMA public TO &lt;user&gt;;</code>
+      </Alert>
+
+      <Form style={{ maxWidth: '560px' }}>
+        <FormGroup label="DB Host" fieldId="db-host" isRequired>
+          <TextInput
+            id="db-host"
+            value={cluster.db_host}
+            onChange={(_e, v) => setCluster({ db_host: v.replace(/^https?:\/\//i, '') })}
+            placeholder="44.201.211.61"
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>IP address or hostname only — do not include <code>http://</code> or <code>https://</code></HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <FormGroup label="DB Port" fieldId="db-port" isRequired>
+          <TextInput
+            id="db-port"
+            type="number"
+            value={String(cluster.db_port)}
+            onChange={(_e, v) => setCluster({ db_port: parseInt(v, 10) || 5432 })}
+            isRequired
+          />
+        </FormGroup>
+
+        <FormGroup label="Database Name" fieldId="db-name" isRequired>
+          <TextInput
+            id="db-name"
+            value={cluster.db_name}
+            onChange={(_e, v) => setCluster({ db_name: v })}
+            placeholder="awx"
+            isRequired
+          />
+        </FormGroup>
+
+        <FormGroup label="DB User" fieldId="db-user" isRequired>
+          <TextInput
+            id="db-user"
+            value={cluster.db_user}
+            onChange={(_e, v) => setCluster({ db_user: v })}
+            isRequired
+          />
+        </FormGroup>
+
+        <FormGroup label="DB Password" fieldId="db-password" isRequired>
+          <TextInput
+            id="db-password"
+            type="password"
+            value={cluster.db_password}
+            onChange={(_e, v) => setCluster({ db_password: v })}
+            isRequired
+          />
+        </FormGroup>
+
+        {testError && testResult === 'failed' && (
+          <Alert variant="danger" title={testError} isInline />
+        )}
+        {testResult === 'success' && (
+          <Alert variant="success" title="Database connection successful" isInline />
+        )}
+
+        <ActionGroup>
+          <Button
+            variant="secondary"
+            onClick={handleTest}
+            isDisabled={!isValid || testing}
+          >
+            {testing ? <><Spinner size="sm" /> Testing...</> : 'Test Connection'}
+          </Button>
+        </ActionGroup>
+
+        <ActionGroup>
+          <Button variant="primary" onClick={onNext} isDisabled={!isValid}>
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepDatabase;

--- a/src/frontend/app/Setup/StepInfra.tsx
+++ b/src/frontend/app/Setup/StepInfra.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepInfraProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const StepInfra: React.FC<StepInfraProps> = ({ onNext, onBack }) => {
+  const infra = useSetupStore((s) => s.infra);
+  const setInfra = useSetupStore((s) => s.setInfra);
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '8px' }}>
+        Infrastructure Settings
+      </Title>
+      <Alert
+        variant="info"
+        isInline
+        title="Only needed for inventory file download"
+        style={{ marginBottom: '16px' }}
+      >
+        These fields are used to generate a pre-filled <code>inventory</code> file for the Ansible installer.
+        They do not affect the currently running application.
+      </Alert>
+
+      <Form style={{ maxWidth: '560px' }}>
+        <FormGroup label="Dashboard Host" fieldId="infra-dashboard-host">
+          <TextInput
+            id="infra-dashboard-host"
+            value={infra.dashboard_host}
+            onChange={(_e, v) => setInfra({ dashboard_host: v })}
+            placeholder="dashboard.example.com"
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>The hostname where the dashboard will be installed</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <FormGroup label="Database Host" fieldId="infra-db-host">
+          <TextInput
+            id="infra-db-host"
+            value={infra.db_host}
+            onChange={(_e, v) => setInfra({ db_host: v })}
+            placeholder="192.168.1.10"
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>Must be an IP address or hostname (not localhost or 127.0.0.1)</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+
+        <FormGroup label="Database Username" fieldId="infra-db-username">
+          <TextInput
+            id="infra-db-username"
+            value={infra.db_username}
+            onChange={(_e, v) => setInfra({ db_username: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="Database Password" fieldId="infra-db-password">
+          <TextInput
+            id="infra-db-password"
+            type="password"
+            value={infra.db_password}
+            onChange={(_e, v) => setInfra({ db_password: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="Database Name" fieldId="infra-db-name">
+          <TextInput
+            id="infra-db-name"
+            value={infra.db_name}
+            onChange={(_e, v) => setInfra({ db_name: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="PostgreSQL Admin Username" fieldId="infra-db-admin-username">
+          <TextInput
+            id="infra-db-admin-username"
+            value={infra.db_admin_username}
+            onChange={(_e, v) => setInfra({ db_admin_username: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="PostgreSQL Admin Password" fieldId="infra-db-admin-password">
+          <TextInput
+            id="infra-db-admin-password"
+            type="password"
+            value={infra.db_admin_password}
+            onChange={(_e, v) => setInfra({ db_admin_password: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="Dashboard Admin Password" fieldId="infra-dashboard-admin-password">
+          <TextInput
+            id="infra-dashboard-admin-password"
+            type="password"
+            value={infra.dashboard_admin_password}
+            onChange={(_e, v) => setInfra({ dashboard_admin_password: v })}
+          />
+        </FormGroup>
+
+        <FormGroup label="HTTP Port" fieldId="infra-http-port">
+          <TextInput
+            id="infra-http-port"
+            type="number"
+            value={String(infra.nginx_http_port)}
+            onChange={(_e, v) => setInfra({ nginx_http_port: parseInt(v, 10) || 8083 })}
+            style={{ maxWidth: '120px' }}
+          />
+        </FormGroup>
+
+        <FormGroup label="HTTPS Port" fieldId="infra-https-port">
+          <TextInput
+            id="infra-https-port"
+            type="number"
+            value={String(infra.nginx_https_port)}
+            onChange={(_e, v) => setInfra({ nginx_https_port: parseInt(v, 10) || 8447 })}
+            style={{ maxWidth: '120px' }}
+          />
+        </FormGroup>
+
+        <FormGroup label="TLS Certificate Path" fieldId="infra-tls-cert">
+          <TextInput
+            id="infra-tls-cert"
+            value={infra.dashboard_tls_cert}
+            onChange={(_e, v) => setInfra({ dashboard_tls_cert: v })}
+            placeholder="/path/to/dashboard.crt (optional)"
+          />
+        </FormGroup>
+
+        <FormGroup label="TLS Key Path" fieldId="infra-tls-key">
+          <TextInput
+            id="infra-tls-key"
+            value={infra.dashboard_tls_key}
+            onChange={(_e, v) => setInfra({ dashboard_tls_key: v })}
+            placeholder="/path/to/dashboard.key (optional)"
+          />
+        </FormGroup>
+
+        <ActionGroup>
+          <Button variant="primary" onClick={onNext}>
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepInfra;

--- a/src/frontend/app/Setup/StepProgress.tsx
+++ b/src/frontend/app/Setup/StepProgress.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Alert, Button, Spinner, Title } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import useSetupStore from '@app/Store/setupStore';
+
+const StepProgress: React.FC = () => {
+  const pollSyncProgress = useSetupStore((s) => s.pollSyncProgress);
+  const syncProgress = useSetupStore((s) => s.syncProgress);
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const poll = async () => {
+      try {
+        const result = await pollSyncProgress();
+        if (!result.has_synced) {
+          timer = setTimeout(poll, 5000);
+        }
+      } catch {
+        timer = setTimeout(poll, 10000);
+      }
+    };
+
+    poll();
+    return () => clearTimeout(timer);
+  }, []);
+
+  const synced = syncProgress?.has_synced;
+
+  return (
+    <div style={{ textAlign: 'center', padding: '32px 0' }}>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '24px' }}>
+        {synced ? 'Setup Complete' : 'Syncing Job Data'}
+      </Title>
+
+      {!synced && (
+        <>
+          <Spinner diameter="60px" aria-label="Syncing data" style={{ marginBottom: '24px' }} />
+          <p style={{ color: 'var(--pf-v6-global--Color--200)' }}>
+            The initial sync is running in the background. This may take several minutes depending
+            on how much historical data is being imported.
+            {' '}Make sure the <code>run_dispatcher</code> process is running.
+          </p>
+        </>
+      )}
+
+      {synced && (
+        <>
+          <Alert
+            variant="success"
+            title="Initial sync complete"
+            isInline
+            style={{ marginBottom: '24px', textAlign: 'left' }}
+          >
+            {syncProgress?.last_synced && (
+              <>Last synced up to: {new Date(syncProgress.last_synced).toLocaleString()}</>
+            )}
+          </Alert>
+          <Button variant="primary" onClick={() => navigate('/')}>
+            Go to Dashboard
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default StepProgress;

--- a/src/frontend/app/Setup/StepReview.tsx
+++ b/src/frontend/app/Setup/StepReview.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepReviewProps {
+  onApply: () => void;
+  onBack: () => void;
+}
+
+const StepReview: React.FC<StepReviewProps> = ({ onApply, onBack }) => {
+  const cluster = useSetupStore((s) => s.cluster);
+  const sync = useSetupStore((s) => s.sync);
+  const costs = useSetupStore((s) => s.costs);
+  const configureStatus = useSetupStore((s) => s.configureStatus);
+  const configureError = useSetupStore((s) => s.configureError);
+  const downloadInventory = useSetupStore((s) => s.downloadInventory);
+  const infra = useSetupStore((s) => s.infra);
+
+  const [downloading, setDownloading] = React.useState(false);
+
+  const syncLabel =
+    sync.mode === 'days'
+      ? `Last ${sync.initial_sync_days} days`
+      : `From ${sync.initial_sync_since}`;
+
+  const handleDownload = async () => {
+    setDownloading(true);
+    try {
+      await downloadInventory();
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        Review Configuration
+      </Title>
+      <p style={{ marginBottom: '24px' }}>
+        Review the settings below, then click <strong>Apply Configuration</strong> to save and start
+        the initial sync. You can also download a pre-filled inventory file for the Ansible installer.
+      </p>
+
+      <DescriptionList isHorizontal style={{ marginBottom: '32px', maxWidth: '560px' }}>
+        <DescriptionListGroup>
+          <DescriptionListTerm>AAP Host</DescriptionListTerm>
+          <DescriptionListDescription>
+            {cluster.protocol}://{cluster.address}:{cluster.port}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>AAP Version</DescriptionListTerm>
+          <DescriptionListDescription>{cluster.aap_version}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Client ID</DescriptionListTerm>
+          <DescriptionListDescription>{cluster.client_id}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>SSL Verification</DescriptionListTerm>
+          <DescriptionListDescription>{cluster.verify_ssl ? 'Enabled' : 'Disabled'}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Initial Sync</DescriptionListTerm>
+          <DescriptionListDescription>{syncLabel}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Monthly Cost</DescriptionListTerm>
+          <DescriptionListDescription>{costs.monthly_subscription_cost}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Engineer Hourly Rate</DescriptionListTerm>
+          <DescriptionListDescription>{costs.engineer_avg_hourly_rate}</DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+
+      {configureError && (
+        <Alert variant="danger" title={configureError} isInline style={{ marginBottom: '16px' }} />
+      )}
+
+      <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+        <Button
+          variant="primary"
+          onClick={onApply}
+          isDisabled={configureStatus === 'pending' || configureStatus === 'success'}
+        >
+          {configureStatus === 'pending'
+            ? <><Spinner size="sm" aria-label="Applying" /> Applying...</>
+            : 'Apply Configuration'}
+        </Button>
+
+        <Button
+          variant="secondary"
+          onClick={handleDownload}
+          isDisabled={downloading || !infra.dashboard_host}
+          title={!infra.dashboard_host ? 'Complete the Infrastructure step to enable download' : undefined}
+        >
+          {downloading ? <><Spinner size="sm" /> Generating...</> : 'Download inventory File'}
+        </Button>
+
+        <Button variant="link" onClick={onBack} isDisabled={configureStatus === 'pending'}>
+          Back
+        </Button>
+      </div>
+
+      {!infra.dashboard_host && (
+        <p style={{ marginTop: '8px', fontSize: '0.875rem', color: 'var(--pf-v6-global--Color--200)' }}>
+          Fill in the Infrastructure step to enable the inventory file download.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default StepReview;

--- a/src/frontend/app/Setup/StepSync.tsx
+++ b/src/frontend/app/Setup/StepSync.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Radio,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepSyncProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const StepSync: React.FC<StepSyncProps> = ({ onNext, onBack }) => {
+  const sync = useSetupStore((s) => s.sync);
+  const setSync = useSetupStore((s) => s.setSync);
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        Initial Sync Range
+      </Title>
+      <p style={{ marginBottom: '24px' }}>
+        How far back should the dashboard pull job history on first sync? Larger ranges take longer to import.
+      </p>
+
+      <Form style={{ maxWidth: '480px' }}>
+        <FormGroup role="radiogroup" isStack fieldId="sync-mode" label="Sync range">
+          <Radio
+            id="sync-mode-days"
+            name="sync-mode"
+            label="Last N days"
+            isChecked={sync.mode === 'days'}
+            onChange={() => setSync({ mode: 'days' })}
+          />
+          <Radio
+            id="sync-mode-since"
+            name="sync-mode"
+            label="From a specific date"
+            isChecked={sync.mode === 'since'}
+            onChange={() => setSync({ mode: 'since' })}
+          />
+        </FormGroup>
+
+        {sync.mode === 'days' && (
+          <FormGroup label="Number of days" fieldId="sync-days" isRequired>
+            <TextInput
+              id="sync-days"
+              type="number"
+              value={String(sync.initial_sync_days)}
+              onChange={(_e, v) => setSync({ initial_sync_days: Math.max(1, parseInt(v, 10) || 1) })}
+              isRequired
+              style={{ maxWidth: '120px' }}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  Syncing more than 90 days may take several minutes depending on job count
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        )}
+
+        {sync.mode === 'since' && (
+          <FormGroup label="Start date" fieldId="sync-since" isRequired>
+            <TextInput
+              id="sync-since"
+              type="date"
+              value={sync.initial_sync_since ?? ''}
+              onChange={(_e, v) => setSync({ initial_sync_since: v || null })}
+              isRequired
+              style={{ maxWidth: '200px' }}
+            />
+          </FormGroup>
+        )}
+
+        <ActionGroup>
+          <Button
+            variant="primary"
+            onClick={onNext}
+            isDisabled={sync.mode === 'since' && !sync.initial_sync_since}
+          >
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepSync;

--- a/src/frontend/app/Setup/StepTokens.tsx
+++ b/src/frontend/app/Setup/StepTokens.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  ExpandableSection,
+  Form,
+  FormGroup,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import useSetupStore from '@app/Store/setupStore';
+
+interface StepTokensProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const StepTokens: React.FC<StepTokensProps> = ({ onNext, onBack }) => {
+  const cluster = useSetupStore((s) => s.cluster);
+  const setCluster = useSetupStore((s) => s.setCluster);
+  const testConnection = useSetupStore((s) => s.testConnection);
+  const connectionTest = useSetupStore((s) => s.connectionTest);
+  const connectionError = useSetupStore((s) => s.connectionError);
+
+  const isValid = cluster.access_token.trim() !== '';
+
+  const handleTest = async () => {
+    await testConnection();
+  };
+
+  return (
+    <div>
+      <Title headingLevel="h2" size="lg" style={{ marginBottom: '16px' }}>
+        OAuth Tokens
+      </Title>
+      <p style={{ marginBottom: '16px' }}>
+        Enter the access and refresh tokens that allow the dashboard to read job data from AAP.
+      </p>
+
+      <ExpandableSection toggleText="How do I get these tokens?" style={{ marginBottom: '24px' }}>
+        <ol style={{ paddingLeft: '20px', lineHeight: '1.8' }}>
+          <li>
+            In AAP Controller, go to <strong>Users → {'<your user>'} → Tokens</strong>
+          </li>
+          <li>
+            Click <strong>Add</strong> and select the OAuth2 application you created earlier
+          </li>
+          <li>Set the scope to <strong>Read</strong></li>
+          <li>
+            After saving, copy both the <strong>Access Token</strong> and the <strong>Refresh Token</strong> shown
+            — the refresh token is only displayed once
+          </li>
+        </ol>
+      </ExpandableSection>
+
+      <Form style={{ maxWidth: '560px' }}>
+        <FormGroup label="Access Token" fieldId="token-access" isRequired>
+          <TextInput
+            id="token-access"
+            type="password"
+            value={cluster.access_token}
+            onChange={(_e, v) => setCluster({ access_token: v })}
+            isRequired
+          />
+        </FormGroup>
+
+        <FormGroup label="Refresh Token" fieldId="token-refresh">
+          <TextInput
+            id="token-refresh"
+            type="password"
+            value={cluster.refresh_token}
+            onChange={(_e, v) => setCluster({ refresh_token: v })}
+            placeholder="Optional — enables automatic token renewal"
+          />
+        </FormGroup>
+
+        {connectionError && (
+          <Alert variant="danger" title={connectionError} isInline />
+        )}
+        {connectionTest === 'success' && (
+          <Alert variant="success" title="Connection successful — tokens are valid" isInline />
+        )}
+
+        <ActionGroup>
+          <Button
+            variant="secondary"
+            onClick={handleTest}
+            isDisabled={!cluster.address || !cluster.access_token || connectionTest === 'testing'}
+          >
+            Test Connection
+          </Button>
+        </ActionGroup>
+
+        <ActionGroup>
+          <Button variant="primary" onClick={onNext} isDisabled={!isValid}>
+            Next
+          </Button>
+          <Button variant="link" onClick={onBack}>
+            Back
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};
+
+export default StepTokens;

--- a/src/frontend/app/Setup/StepWelcome.tsx
+++ b/src/frontend/app/Setup/StepWelcome.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { CheckCircleIcon, CubesIcon, KeyIcon, ClockIcon, CogIcon } from '@patternfly/react-icons';
+
+interface StepWelcomeProps {
+  onNext: () => void;
+}
+
+interface PrereqCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: React.ReactNode;
+}
+
+const PrereqCard: React.FC<PrereqCardProps> = ({ icon, title, description }) => (
+  <div style={{
+    display: 'flex',
+    gap: '16px',
+    padding: '16px',
+    borderRadius: '8px',
+    border: '1px solid var(--pf-v6-global--BorderColor--100)',
+    background: 'var(--pf-v6-global--BackgroundColor--100)',
+    marginBottom: '12px',
+  }}>
+    <div style={{
+      width: '36px',
+      height: '36px',
+      borderRadius: '8px',
+      background: 'var(--pf-v6-global--primary-color--100)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: '#fff',
+      flexShrink: 0,
+      fontSize: '1rem',
+    }}>
+      {icon}
+    </div>
+    <div>
+      <div style={{ fontWeight: 600, marginBottom: '4px', fontSize: '0.9rem' }}>{title}</div>
+      <div style={{ color: 'var(--pf-v6-global--Color--200)', fontSize: '0.85rem', lineHeight: 1.5 }}>
+        {description}
+      </div>
+    </div>
+  </div>
+);
+
+const StepWelcome: React.FC<StepWelcomeProps> = ({ onNext }) => (
+  <div>
+    <p style={{ fontSize: '0.95rem', color: 'var(--pf-v6-global--Color--200)', marginBottom: '32px', lineHeight: 1.6 }}>
+      This wizard connects the dashboard to your Ansible Automation Platform (AAP) cluster
+      and starts syncing job data. It takes about 5 minutes.
+    </p>
+
+    <div style={{ marginBottom: '8px', fontWeight: 600, fontSize: '0.85rem', color: 'var(--pf-v6-global--Color--200)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+      Before you begin, you will need
+    </div>
+    <div style={{ marginBottom: '32px' }}>
+      <PrereqCard
+        icon={<CubesIcon />}
+        title="OAuth2 application in AAP Controller"
+        description={
+          <>
+            Create an app with grant type <strong>authorization-code</strong> and
+            client type <strong>Confidential</strong>. Note the <strong>client_id</strong> and <strong>client_secret</strong>.
+          </>
+        }
+      />
+      <PrereqCard
+        icon={<KeyIcon />}
+        title="Access and refresh tokens"
+        description={
+          <>
+            Create a token in AAP for that OAuth2 application with scope <strong>Read</strong>.
+            Copy both the access token and refresh token — the refresh token is shown only once.
+          </>
+        }
+      />
+      <PrereqCard
+        icon={<CogIcon />}
+        title="AAP Controller host and version"
+        description="The hostname or IP address of your AAP Controller, and whether it is version 2.4, 2.5, or 2.6."
+      />
+      <PrereqCard
+        icon={<ClockIcon />}
+        title="How far back to sync job history"
+        description="You'll choose how many days of historical job data to import on first sync. More days means a longer initial import."
+      />
+    </div>
+
+    <div style={{
+      padding: '12px 16px',
+      borderRadius: '6px',
+      background: 'rgba(0, 102, 204, 0.08)',
+      border: '1px solid rgba(0, 102, 204, 0.2)',
+      marginBottom: '32px',
+      fontSize: '0.85rem',
+      color: 'var(--pf-v6-global--Color--200)',
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: '10px',
+    }}>
+      <CheckCircleIcon style={{ color: 'var(--pf-v6-global--primary-color--100)', marginTop: '1px', flexShrink: 0 }} />
+      <span>
+        At the end you can also download a pre-filled <code>inventory</code> file
+        for use with the Ansible-based installer.
+      </span>
+    </div>
+
+    <Button variant="primary" size="lg" onClick={onNext}>
+      Get Started →
+    </Button>
+  </div>
+);
+
+export default StepWelcome;

--- a/src/frontend/app/Setup/index.ts
+++ b/src/frontend/app/Setup/index.ts
@@ -1,0 +1,1 @@
+export { default as SetupWizard } from './SetupWizard';

--- a/src/frontend/app/Store/clusterStore.ts
+++ b/src/frontend/app/Store/clusterStore.ts
@@ -1,0 +1,186 @@
+import { create } from 'zustand';
+import api from '@app/client/apiClient';
+import { ClusterInfo, ClusterFormData, ConnectionTestResult } from '@app/Types/ClusterTypes';
+
+type ClusterStoreState = {
+  clusters: ClusterInfo[];
+  loading: boolean;
+  saving: boolean;
+  isModalOpen: boolean;
+  formMode: 'list' | 'add' | 'edit';
+  editingCluster: ClusterInfo | null;
+  syncing: number[];
+  connectionTest: 'idle' | 'testing' | 'success' | 'failed';
+  connectionError: string | null;
+  error: string | null;
+};
+
+type ClusterStoreActions = {
+  fetchClusters: () => Promise<void>;
+  openModal: () => void;
+  closeModal: () => void;
+  startAdd: () => void;
+  startEdit: (cluster: ClusterInfo) => void;
+  backToList: () => void;
+  saveCluster: (data: ClusterFormData) => Promise<void>;
+  deleteCluster: (id: number) => Promise<void>;
+  syncCluster: (id: number) => Promise<void>;
+  testConnection: (
+    data: Pick<ClusterFormData, 'protocol' | 'address' | 'port' | 'access_token' | 'verify_ssl'>
+  ) => Promise<ConnectionTestResult>;
+  testDbConnection: (
+    data: Pick<ClusterFormData, 'db_host' | 'db_port' | 'db_name' | 'db_user' | 'db_password'>
+  ) => Promise<ConnectionTestResult>;
+};
+
+const useClusterStore = create<ClusterStoreState & ClusterStoreActions>((set, get) => ({
+  clusters: [],
+  loading: false,
+  saving: false,
+  isModalOpen: false,
+  formMode: 'list',
+  editingCluster: null,
+  syncing: [],
+  connectionTest: 'idle',
+  connectionError: null,
+  error: null,
+
+  fetchClusters: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await api.get<ClusterInfo[]>('/api/v1/clusters/');
+      set({ clusters: res.data, loading: false });
+    } catch {
+      set({ loading: false, error: 'Failed to load clusters' });
+    }
+  },
+
+  openModal: () => {
+    set({ isModalOpen: true, formMode: 'list' });
+    get().fetchClusters();
+  },
+
+  closeModal: () => {
+    set({
+      isModalOpen: false,
+      formMode: 'list',
+      editingCluster: null,
+      connectionTest: 'idle',
+      connectionError: null,
+      error: null,
+    });
+  },
+
+  startAdd: () => {
+    set({ formMode: 'add', editingCluster: null, connectionTest: 'idle', connectionError: null });
+  },
+
+  startEdit: (cluster: ClusterInfo) => {
+    set({ formMode: 'edit', editingCluster: cluster, connectionTest: 'idle', connectionError: null });
+  },
+
+  backToList: () => {
+    set({ formMode: 'list', editingCluster: null, connectionTest: 'idle', connectionError: null });
+  },
+
+  saveCluster: async (data: ClusterFormData) => {
+    set({ saving: true, error: null });
+    const { formMode, editingCluster } = get();
+    try {
+      const payload: Record<string, unknown> = {
+        protocol: data.protocol,
+        address: data.address,
+        port: data.port,
+        aap_version: data.aap_version,
+        verify_ssl: data.verify_ssl,
+        sync_mode: data.sync_mode,
+      };
+      if (data.sync_mode === 'database') {
+        payload.db_host = data.db_host;
+        payload.db_port = data.db_port;
+        payload.db_name = data.db_name;
+        payload.db_user = data.db_user;
+        if (data.db_password) {
+          payload.db_password = data.db_password;
+        }
+      } else {
+        payload.client_id = data.client_id;
+        payload.client_secret = data.client_secret || undefined;
+        payload.access_token = data.access_token || undefined;
+        payload.refresh_token = data.refresh_token || undefined;
+      }
+      if (formMode === 'edit' && editingCluster) {
+        await api.patch(`/api/v1/clusters/${editingCluster.id}/`, payload);
+      } else {
+        await api.post('/api/v1/clusters/', payload);
+      }
+      set({ saving: false });
+      await get().fetchClusters();
+      get().backToList();
+    } catch {
+      set({ saving: false, error: 'Failed to save cluster' });
+      throw new Error('Failed to save cluster');
+    }
+  },
+
+  deleteCluster: async (id: number) => {
+    set({ error: null });
+    try {
+      await api.delete(`/api/v1/clusters/${id}/`);
+      await get().fetchClusters();
+    } catch {
+      set({ error: 'Failed to delete cluster' });
+      throw new Error('Failed to delete cluster');
+    }
+  },
+
+  syncCluster: async (id: number) => {
+    set((s) => ({ syncing: [...s.syncing, id] }));
+    try {
+      await api.post(`/api/v1/clusters/${id}/sync/`);
+    } catch {
+      // sync errors are non-fatal; the backend will update status separately
+    } finally {
+      setTimeout(() => {
+        set((s) => ({ syncing: s.syncing.filter((sid) => sid !== id) }));
+      }, 3000);
+    }
+  },
+
+  testConnection: async (
+    data: Pick<ClusterFormData, 'protocol' | 'address' | 'port' | 'access_token' | 'verify_ssl'>
+  ): Promise<ConnectionTestResult> => {
+    set({ connectionTest: 'testing', connectionError: null });
+    try {
+      const res = await api.post<ConnectionTestResult>('/api/v1/clusters/test_connection/', data);
+      const result = res.data;
+      set({ connectionTest: result.success ? 'success' : 'failed', connectionError: result.error });
+      return result;
+    } catch {
+      const fallback: ConnectionTestResult = { success: false, detected_version: null, error: 'Connection test failed' };
+      set({ connectionTest: 'failed', connectionError: fallback.error });
+      return fallback;
+    }
+  },
+
+  testDbConnection: async (
+    data: Pick<ClusterFormData, 'db_host' | 'db_port' | 'db_name' | 'db_user' | 'db_password'>
+  ): Promise<ConnectionTestResult> => {
+    set({ connectionTest: 'testing', connectionError: null });
+    try {
+      const res = await api.post<ConnectionTestResult>('/api/v1/clusters/test_connection/', {
+        sync_mode: 'database',
+        ...data,
+      });
+      const result = res.data;
+      set({ connectionTest: result.success ? 'success' : 'failed', connectionError: result.error });
+      return result;
+    } catch {
+      const fallback: ConnectionTestResult = { success: false, detected_version: null, error: 'Connection test failed' };
+      set({ connectionTest: 'failed', connectionError: fallback.error });
+      return fallback;
+    }
+  },
+}));
+
+export default useClusterStore;

--- a/src/frontend/app/Store/setupStore.ts
+++ b/src/frontend/app/Store/setupStore.ts
@@ -1,0 +1,250 @@
+import { create } from 'zustand';
+import api from '@app/client/apiClient';
+import {
+  ClusterSetupData,
+  CostSetupData,
+  ConnectionTestResult,
+  InfraSetupData,
+  SetupMeResponse,
+  SetupStatus,
+  SyncProgress,
+  SyncSetupData,
+} from '@app/Types/SetupTypes';
+
+const DEFAULT_CLUSTER: ClusterSetupData = {
+  protocol: 'https',
+  address: '',
+  port: 443,
+  aap_version: 'AAP 2.5',
+  verify_ssl: true,
+  sync_mode: 'api',
+  client_id: '',
+  client_secret: '',
+  access_token: '',
+  refresh_token: '',
+  db_host: '',
+  db_port: 5432,
+  db_name: 'awx',
+  db_user: '',
+  db_password: '',
+};
+
+const DEFAULT_SYNC: SyncSetupData = {
+  mode: 'days',
+  initial_sync_days: 30,
+  initial_sync_since: null,
+};
+
+const DEFAULT_INFRA: InfraSetupData = {
+  dashboard_host: '',
+  db_host: '',
+  db_username: 'aapdashboard',
+  db_password: '',
+  db_name: 'aapdashboard',
+  db_admin_username: 'postgres',
+  db_admin_password: '',
+  dashboard_admin_password: '',
+  nginx_http_port: 8083,
+  nginx_https_port: 8447,
+  dashboard_tls_cert: '',
+  dashboard_tls_key: '',
+};
+
+const DEFAULT_COSTS: CostSetupData = {
+  monthly_subscription_cost: 50000,
+  engineer_avg_hourly_rate: 50,
+};
+
+type SetupStoreState = {
+  cluster: ClusterSetupData;
+  sync: SyncSetupData;
+  infra: InfraSetupData;
+  costs: CostSetupData;
+  connectionTest: 'idle' | 'testing' | 'success' | 'failed';
+  connectionError: string | null;
+  configureStatus: 'idle' | 'pending' | 'success' | 'failed';
+  configureError: string | null;
+  syncProgress: SyncProgress | null;
+  localLoginError: string | null;
+  setupMe: SetupMeResponse | null;
+  setupRequired: boolean | null;
+};
+
+type SetupStoreActions = {
+  setCluster: (data: Partial<ClusterSetupData>) => void;
+  setSync: (data: Partial<SyncSetupData>) => void;
+  setInfra: (data: Partial<InfraSetupData>) => void;
+  setCosts: (data: Partial<CostSetupData>) => void;
+  fetchSetupStatus: () => Promise<boolean>;
+  fetchSetupMe: () => Promise<SetupMeResponse>;
+  localLogin: (username: string, password: string) => Promise<void>;
+  testConnection: () => Promise<ConnectionTestResult>;
+  configure: () => Promise<void>;
+  pollSyncProgress: () => Promise<SyncProgress>;
+  downloadInventory: () => Promise<void>;
+};
+
+export const useSetupStore = create<SetupStoreState & SetupStoreActions>((set, get) => ({
+  cluster: { ...DEFAULT_CLUSTER },
+  sync: { ...DEFAULT_SYNC },
+  infra: { ...DEFAULT_INFRA },
+  costs: { ...DEFAULT_COSTS },
+  connectionTest: 'idle',
+  connectionError: null,
+  configureStatus: 'idle',
+  configureError: null,
+  syncProgress: null,
+  localLoginError: null,
+  setupMe: null,
+  setupRequired: null,
+
+  setCluster: (data) => set((s) => ({ cluster: { ...s.cluster, ...data } })),
+  setSync: (data) => set((s) => ({ sync: { ...s.sync, ...data } })),
+  setInfra: (data) => set((s) => ({ infra: { ...s.infra, ...data } })),
+  setCosts: (data) => set((s) => ({ costs: { ...s.costs, ...data } })),
+
+  fetchSetupStatus: async () => {
+    const res = await api.get<SetupStatus>('/api/v1/setup/status/');
+    set({ setupRequired: res.data.setup_required });
+    return res.data.setup_required;
+  },
+
+  fetchSetupMe: async () => {
+    const res = await api.get<SetupMeResponse>('/api/v1/setup/me/');
+    set({ setupMe: res.data });
+    return res.data;
+  },
+
+  localLogin: async (username, password) => {
+    set({ localLoginError: null });
+    try {
+      await api.post('/api/v1/setup/local_login/', { username, password });
+      await get().fetchSetupMe();
+    } catch (e: unknown) {
+      const msg = (e as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Login failed';
+      set({ localLoginError: msg });
+      throw new Error(msg);
+    }
+  },
+
+  testConnection: async () => {
+    set({ connectionTest: 'testing', connectionError: null });
+    const { cluster } = get();
+    try {
+      const res = await api.post<ConnectionTestResult>('/api/v1/setup/test_connection/', {
+        protocol: cluster.protocol,
+        address: cluster.address,
+        port: cluster.port,
+        access_token: cluster.access_token,
+        verify_ssl: cluster.verify_ssl,
+      });
+      const result = res.data;
+      set({ connectionTest: result.success ? 'success' : 'failed', connectionError: result.error });
+      return result;
+    } catch {
+      set({ connectionTest: 'failed', connectionError: 'Connection test failed' });
+      return { success: false, detected_version: null, error: 'Connection test failed' };
+    }
+  },
+
+  configure: async () => {
+    set({ configureStatus: 'pending', configureError: null });
+    const { cluster, sync, costs } = get();
+    const clusterPayload: Record<string, unknown> = {
+      protocol: cluster.protocol,
+      address: cluster.address,
+      port: cluster.port,
+      aap_version: cluster.aap_version,
+      verify_ssl: cluster.verify_ssl,
+      sync_mode: cluster.sync_mode,
+    };
+    if (cluster.sync_mode === 'database') {
+      clusterPayload.db_host = cluster.db_host;
+      clusterPayload.db_port = cluster.db_port;
+      clusterPayload.db_name = cluster.db_name;
+      clusterPayload.db_user = cluster.db_user;
+      if (cluster.db_password) {
+        clusterPayload.db_password = cluster.db_password;
+      }
+    } else {
+      clusterPayload.client_id = cluster.client_id;
+      clusterPayload.client_secret = cluster.client_secret;
+      clusterPayload.access_token = cluster.access_token;
+      clusterPayload.refresh_token = cluster.refresh_token;
+    }
+    const payload = {
+      cluster: clusterPayload,
+      sync: {
+        initial_sync_days: sync.mode === 'days' ? sync.initial_sync_days : undefined,
+        initial_sync_since: sync.mode === 'since' ? sync.initial_sync_since : null,
+      },
+      costs: {
+        monthly_subscription_cost: costs.monthly_subscription_cost,
+        engineer_avg_hourly_rate: costs.engineer_avg_hourly_rate,
+      },
+    };
+    try {
+      await api.post('/api/v1/setup/configure/', payload);
+      set({ configureStatus: 'success' });
+    } catch (e: unknown) {
+      const msg = (e as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Configuration failed';
+      set({ configureStatus: 'failed', configureError: msg });
+      throw new Error(msg);
+    }
+  },
+
+  pollSyncProgress: async () => {
+    const res = await api.get<SyncProgress>('/api/v1/setup/sync_progress/');
+    set({ syncProgress: res.data });
+    return res.data;
+  },
+
+  downloadInventory: async () => {
+    const { cluster, sync, infra, costs } = get();
+    const inventoryClusterPayload: Record<string, unknown> = {
+      protocol: cluster.protocol,
+      address: cluster.address,
+      port: cluster.port,
+      aap_version: cluster.aap_version,
+      verify_ssl: cluster.verify_ssl,
+      sync_mode: cluster.sync_mode,
+    };
+    if (cluster.sync_mode === 'database') {
+      inventoryClusterPayload.db_host = cluster.db_host;
+      inventoryClusterPayload.db_port = cluster.db_port;
+      inventoryClusterPayload.db_name = cluster.db_name;
+      inventoryClusterPayload.db_user = cluster.db_user;
+      if (cluster.db_password) {
+        inventoryClusterPayload.db_password = cluster.db_password;
+      }
+    } else {
+      inventoryClusterPayload.client_id = cluster.client_id;
+      inventoryClusterPayload.client_secret = cluster.client_secret;
+      inventoryClusterPayload.access_token = cluster.access_token;
+      inventoryClusterPayload.refresh_token = cluster.refresh_token;
+    }
+    const payload = {
+      cluster: inventoryClusterPayload,
+      sync: {
+        initial_sync_days: sync.mode === 'days' ? sync.initial_sync_days : undefined,
+        initial_sync_since: sync.mode === 'since' ? sync.initial_sync_since : null,
+      },
+      costs: {
+        monthly_subscription_cost: costs.monthly_subscription_cost,
+        engineer_avg_hourly_rate: costs.engineer_avg_hourly_rate,
+      },
+      infra: { ...infra },
+    };
+    const res = await api.post('/api/v1/setup/inventory/', payload, { responseType: 'blob' });
+    const url = window.URL.createObjectURL(new Blob([res.data as BlobPart], { type: 'text/plain' }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'inventory');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  },
+}));
+
+export default useSetupStore;

--- a/src/frontend/app/Types/ClusterTypes.ts
+++ b/src/frontend/app/Types/ClusterTypes.ts
@@ -1,0 +1,44 @@
+export type AAPVersion = 'AAP 2.4' | 'AAP 2.5' | 'AAP 2.6' | 'AAP 2.7';
+
+export interface ClusterInfo {
+  id: number;
+  protocol: 'http' | 'https';
+  address: string;
+  port: number;
+  aap_version: AAPVersion;
+  verify_ssl: boolean;
+  sync_mode: 'api' | 'database';
+  client_id: string;
+  has_access_token: boolean;
+  has_refresh_token: boolean;
+  db_host: string;
+  db_port: number;
+  db_name: string;
+  db_user: string;
+  has_db_password: boolean;
+  last_synced: string | null;
+}
+
+export interface ClusterFormData {
+  protocol: 'http' | 'https';
+  address: string;
+  port: number;
+  aap_version: AAPVersion;
+  verify_ssl: boolean;
+  sync_mode: 'api' | 'database';
+  client_id: string;
+  client_secret: string;
+  access_token: string;
+  refresh_token: string;
+  db_host: string;
+  db_port: number;
+  db_name: string;
+  db_user: string;
+  db_password: string;
+}
+
+export interface ConnectionTestResult {
+  success: boolean;
+  detected_version: string | null;
+  error: string | null;
+}

--- a/src/frontend/app/Types/SetupTypes.ts
+++ b/src/frontend/app/Types/SetupTypes.ts
@@ -1,0 +1,69 @@
+export type AAPVersion = 'AAP 2.4' | 'AAP 2.5' | 'AAP 2.6' | 'AAP 2.7';
+
+export interface ClusterSetupData {
+  protocol: 'http' | 'https';
+  address: string;
+  port: number;
+  aap_version: AAPVersion;
+  verify_ssl: boolean;
+  sync_mode: 'api' | 'database';
+  client_id: string;
+  client_secret: string;
+  access_token: string;
+  refresh_token: string;
+  db_host: string;
+  db_port: number;
+  db_name: string;
+  db_user: string;
+  db_password: string;
+}
+
+export type SyncMode = 'days' | 'since';
+
+export interface SyncSetupData {
+  mode: SyncMode;
+  initial_sync_days: number;
+  initial_sync_since: string | null;
+}
+
+export interface InfraSetupData {
+  dashboard_host: string;
+  db_host: string;
+  db_username: string;
+  db_password: string;
+  db_name: string;
+  db_admin_username: string;
+  db_admin_password: string;
+  dashboard_admin_password: string;
+  nginx_http_port: number;
+  nginx_https_port: number;
+  dashboard_tls_cert: string;
+  dashboard_tls_key: string;
+}
+
+export interface CostSetupData {
+  monthly_subscription_cost: number;
+  engineer_avg_hourly_rate: number;
+}
+
+export interface SetupStatus {
+  setup_required: boolean;
+}
+
+export interface SetupMeResponse {
+  authenticated: boolean;
+  is_superuser: boolean;
+  username: string | null;
+}
+
+export interface ConnectionTestResult {
+  success: boolean;
+  detected_version: string | null;
+  error: string | null;
+}
+
+export interface SyncProgress {
+  has_synced: boolean;
+  last_synced: string | null;
+  cluster_configured: boolean;
+}

--- a/src/frontend/app/routes.tsx
+++ b/src/frontend/app/routes.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { Dashboard } from '@app/Dashboard';
 import { Login } from '@app/Components';
+import { SetupWizard } from '@app/Setup';
 import { useAuthStore } from '@app/Store/authStore';
+import useSetupStore from '@app/Store/setupStore';
+
 export interface IAppRoute {
   label?: string; // Excluding the label will exclude the route from the nav sidebar in AppLayout
   element: React.ReactElement;
@@ -39,19 +42,30 @@ const routes: IAppRoute[] = [
     path: '/',
     title: 'PatternFly Seed | Main Dashboard',
   },
+  {
+    element: <SetupWizard />,
+    exact: true,
+    label: 'Setup',
+    path: '/setup',
+    title: 'Automation Dashboard Setup',
+  },
 ];
 
 
 const AppRoutes = (): React.ReactElement => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
+  const setupRequired = useSetupStore((state) => state.setupRequired);
 
   return (
     <Routes>
       {routes.map((route: IAppRoute, index: number) => (
         <Route
-          path={route.path} 
+          path={route.path}
           element={
-            isAuthenticated ? (
+            route.path === '/setup' ? (
+              // /setup is accessible whenever setup is required, regardless of AAP OAuth auth state
+              setupRequired === false ? <Navigate to="/" replace /> : route.element
+            ) : isAuthenticated ? (
               route.path === '/login' || route.path === '/auth-callback' ? (
                 <Navigate to="/" replace />
               ) : (
@@ -61,12 +75,12 @@ const AppRoutes = (): React.ReactElement => {
               route.path === '/' ? <Navigate to="/login" replace /> : route.element
             )
           }
-          key={index} 
+          key={index}
         />
       ))}
-      <Route path="*" element={<Navigate to={isAuthenticated ? "/" : "/login"} replace />} />
+      <Route path="*" element={<Navigate to={isAuthenticated ? '/' : '/login'} replace />} />
     </Routes>
-  ) 
+  );
 };
 
 export { AppRoutes, routes };

--- a/tests/playwright/support/helpers.ts
+++ b/tests/playwright/support/helpers.ts
@@ -3,6 +3,7 @@ import {
   mockAuthSettingsRoute,
   mockTokenRoute,
   mockMeRoute,
+  mockSetupStatusRoute,
   mockTemplateOptionsRoute,
   mockTemplatesRoute,
   mockOrganizationsRoute,
@@ -69,6 +70,7 @@ export async function loginUser(
   await mockAuthSettingsRoute(page);
   await mockTokenRoute(page);
   await mockMeRoute(page);
+  await mockSetupStatusRoute(page, false);
   await mockTemplateOptionsRoute(page, templateOptionsResponse);
   await mockTemplatesRoute(page, templatesResponse);
   await mockOrganizationsRoute(page, organizationsResponse);

--- a/tests/playwright/support/interceptors.ts
+++ b/tests/playwright/support/interceptors.ts
@@ -229,3 +229,16 @@ export async function mockCostsRoute(
     });
   });
 }
+
+export async function mockSetupStatusRoute(
+  page: import("playwright").Page,
+  setupRequired: boolean = false,
+): Promise<void> {
+  await page.route(`**/api/v1/setup/status/`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_required: setupRequired }),
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Setup wizard** — first-run `/setup` route guides new customers through connecting an AAP cluster, configuring sync settings, and setting subscription costs; generates a downloadable Ansible inventory file as an alternative to the CLI installer
- **Direct database sync** — new `sync_mode=database` on clusters reads job data straight from AAP's PostgreSQL via psycopg3 (`main_unifiedjob`, `main_job`, `main_jobhostsummary`), bypassing OAuth2 entirely; migration 0025 adds the new fields
- **Cluster management modal** — settings cog in the dashboard masthead opens an overlay for full cluster CRUD, sync-on-demand, and test-connection for both API and database modes
- **AAP 2.7 support** — `ClusterVersionChoices.AAP27` added; uses same gateway paths as 2.5/2.6
- **Dev login** — `DevLoginView` creates a real JWT for a local Django account; gated behind `ALLOW_DEV_LOGIN=True` (default `False`), enabled only in the compose dev settings file
- **Compose dev stack** — `compose.dev-override.yml` uses public postgres:15/redis:6 images, mounts `src/backend` for live Python reload, and includes dev settings at `/etc/dashboard/conf.d/`; nginx `try_files` fix for SPA routing

## Notable changes
- `AAPAuthentication.enforce_csrf()` now accepts both `X-XSRF-TOKEN` (axios) and `X-CSRFToken` (Django default) using a double-submit cookie check — removes dependency on `CSRF_TRUSTED_ORIGINS` configuration
- `AAPSettingsView` returns empty JSON instead of 500 when AAP OAuth is not configured, allowing the login page to gracefully fall back to local login
- `launch_automation_dashboard.sh` now starts `run_dispatcher` alongside nginx and runserver so sync jobs are processed automatically in the compose dev environment

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to new authentication paths (dev/local login, custom CSRF enforcement) and a new DB-direct sync pipeline that handles credentials and imports job data, plus significant new API surface for cluster/setup management.
> 
> **Overview**
> Adds a **first-run setup flow**: new `/setup` UI and backend endpoints to authenticate via local superuser session, test connectivity, persist initial cluster + cost configuration, enqueue an initial sync job, and generate a downloadable installer `inventory` file.
> 
> Introduces **cluster management** over the REST API (`/api/v1/clusters/`) and a React modal for admin users to create/edit/delete clusters, test API/DB connectivity, and trigger manual syncs; cluster secrets are stored encrypted and read APIs only expose presence flags.
> 
> Implements **direct database sync mode** (`Cluster.sync_mode=database`) with new `Cluster` DB connection fields + migration, a `DbConnector` that reads AAP tables via `psycopg`, and task logic to route sync jobs through DB or OAuth API connectors; also adds **AAP 2.7** version detection/support.
> 
> Hardens/adjusts auth + dev UX: `enforce_csrf()` switches to strict double-submit cookie checking (accepts `X-XSRF-TOKEN` and `X-CSRFToken`), `AAPSettingsView` returns empty settings when OAuth provider is unconfigured, and a gated `dev_login` endpoint is added; compose/dev scripts/configs are updated to start `run_dispatcher`, fix SPA routing, and provide a public-image override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7df2600793720ff43678d8e7b7eddba29e92d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Setup Wizard with multi-step cluster, token/database, sync range, infra, costs, review, and progress UI.
  * Cluster management UI: add/edit/delete clusters, test API/DB connections, manual "Sync Now", and inventory file download.
  * Optional database-direct sync mode and support for AAP 2.7.
  * Dev/local login fallback for development/setup.

* **Bug Fixes**
  * Safer dropdown/date handling and stricter CSRF double-submit validation.

* **Documentation**
  * Added repository guidance and developer setup notes.

* **Chores**
  * Updated local Docker compose and development environment configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->