### PR TITLE
AAP-74332 fe deps - continue

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "sirv dist --cors --single --host",
     "start:dev": "vite",
     "test": "playwright test",
+    "test:retry": "playwright test || playwright test --last-failed",
     "eslint": "eslint --ext .tsx,.js ./src/frontend",
     "lint": "npm run eslint",
     "format": "prettier --check --write ./src/frontend/**/*.{tsx,ts}",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
Forgot to push 2 commits for #238

npm run test had 3 failures before #238 change - I run it only once.
After #238 change, it has 2 to 4 failures, and failed tests are not always the same. Seems like a timing issure.
Running all tests serially helps, but will be slower. So PR adds a npm run test:retry.