### PR TITLE
AAP-76050 Add support for AAP 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ nano local_settings.py
 **Edit the following variables in `local_settings.py`:**
 
 - `url`: Change from `aap.example.com` to your AAP VM IP
-- `user_data_endpoint`: Change from `/api/v2/me/` to `/api/gateway/v1/me/` for AAP v2.5
+- `user_data_endpoint`: Change from `/api/v2/me/` to `/api/gateway/v1/me/` for AAP v2.5 and later
 - `client_id`: Replace `"TODO"` with your OAuth application client ID
 - `client_secret`: Replace `"TODO"` with your OAuth application client secret
 
@@ -218,7 +218,7 @@ AAP_AUTH_PROVIDER = {
     #
     # For AAP v2.4
     "user_data_endpoint": "/v2/me/",
-    # For AAP v2.5, v2.6
+    # For AAP v2.5, v2.6, v2.7
     # "user_data_endpoint": "/api/gateway/v1/me/",
     #
     "check_ssl": False,

--- a/docs/02-data-sync-architecture.md
+++ b/docs/02-data-sync-architecture.md
@@ -95,7 +95,7 @@ class ApiConnector:
 
 **Key Features**:
 - **OAuth2 Authentication**: Handles bearer token authentication
-- **Version Detection**: Auto-detects AAP 2.4 vs 2.5 API differences
+- **Version Detection**: Auto-detects AAP 2.4, 2.5, 2.6, and 2.7 API differences
 - **Incremental Sync**: Only fetches jobs since last successful sync
 - **Pagination Handling**: Automatically follows API pagination
 - **Error Handling**: Robust handling of network and API errors
@@ -307,7 +307,7 @@ class Cluster(models.Model):
     port = IntegerField()           # 443
     access_token = BinaryField()    # Encrypted OAuth2 token
     verify_ssl = BooleanField()     # SSL verification
-    aap_version = CharField()       # AAP 2.4 or 2.5
+    aap_version = CharField()       # AAP 2.4, 2.5, 2.6, or 2.7
 
 # Temporary Storage
 class ClusterSyncData(models.Model):

--- a/docs/06-database-schema.md
+++ b/docs/06-database-schema.md
@@ -116,7 +116,7 @@ ON clusters_cluster(protocol, address, port);
 
 **Key Features**:
 - **Encrypted Tokens**: OAuth2 access tokens stored as encrypted binary data
-- **Version Support**: Handles both AAP 2.4 and 2.5 API differences
+- **Version Support**: Handles AAP 2.4, 2.5, 2.6, and 2.7 API differences
 - **SSL Configuration**: Per-cluster SSL verification settings
 
 ### 2. Job Execution Data

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
@@ -118,10 +118,12 @@
       2.4: "{{ aap_auth_provider_host }}/api"
       2.5: "{{ aap_auth_provider_host }}"
       2.6: "{{ aap_auth_provider_host }}"
+      2.7: "{{ aap_auth_provider_host }}"
     map_to_aap_user_data_endpoint:
       2.4: "/v2/me/"
       2.5: "/api/gateway/v1/me/"
       2.6: "/api/gateway/v1/me/"
+      2.7: "/api/gateway/v1/me/"
 
 # - name: Add rsyslog to systemd services list
 #   ansible.builtin.set_fact:

--- a/setup/inventory.example
+++ b/setup/inventory.example
@@ -7,7 +7,7 @@ host.example.com ansible_connection=local
 aap_auth_provider_name=Ansible Automation Platform
 # aap_auth_provider_protocol - http or https
 aap_auth_provider_protocol=https
-# AAP version - 2.4, 2.5 or 2.6
+# AAP version - 2.4, 2.5, 2.6 or 2.7
 aap_auth_provider_aap_version=2.5
 # aap_auth_provider_host - AAP IP or DNS name, with optional port
 aap_auth_provider_host=my-aap.example.com

--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -326,11 +326,13 @@ class ApiConnector:
         return response
 
     def detect_aap_version(self):
-        logger.info(f'Checking if is AAP 2.5 ... 2.6 at {self.cluster.base_url}')
+        logger.info(f'Checking if is AAP 2.5 ... 2.7 at {self.cluster.base_url}')
         response25 = self.ping("/api/gateway/v1/ping/")
         if response25:
-            logger.debug(f"AAP 2.5/2.6 ping response: {response25}")
-            if response25["version"] == "2.6":
+            logger.debug(f"AAP 2.5/2.6/2.7 ping response: {response25}")
+            if response25["version"] == "2.7":
+                return ClusterVersionChoices.AAP27
+            elif response25["version"] == "2.6":
                 return ClusterVersionChoices.AAP26
             elif response25["version"] == "2.5":
                 return ClusterVersionChoices.AAP25

--- a/src/backend/apps/clusters/migrations/0025_add_aap_27_support.py
+++ b/src/backend/apps/clusters/migrations/0025_add_aap_27_support.py
@@ -1,0 +1,27 @@
+# Generated migration for AAP 2.7 support
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clusters", "0024_delete_costs"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="cluster",
+            name="aap_version",
+            field=models.CharField(
+                choices=[
+                    ("AAP 2.7", "AAP 2.7"),
+                    ("AAP 2.6", "AAP 2.6"),
+                    ("AAP 2.5", "AAP 2.5"),
+                    ("AAP 2.4", "AAP 2.4"),
+                ],
+                default="AAP 2.4",
+                max_length=15,
+            ),
+        ),
+    ]

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -61,6 +61,7 @@ class CreatUpdateModel(models.Model):
 
 
 class ClusterVersionChoices(models.TextChoices):
+    AAP27 = "AAP 2.7", "AAP 2.7"
     AAP26 = "AAP 2.6", "AAP 2.6"
     AAP25 = "AAP 2.5", "AAP 2.5"
     AAP24 = "AAP 2.4", "AAP 2.4"
@@ -87,7 +88,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def api_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return f'/api/controller/v2'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'/api/v2'
@@ -96,7 +97,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def gui_base_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return f'{self.base_url}/execution/'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'{self.base_url}/#/'
@@ -105,7 +106,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def oauth_token_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26]:
+        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
             return '/o/token/'
         elif self.aap_version in [ClusterVersionChoices.AAP24]:
             return '/api/o/token/'

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -79,6 +79,13 @@ class Cluster(CreatUpdateModel):
     aap_version = models.CharField(max_length=15, choices=ClusterVersionChoices.choices,
                                    default=ClusterVersionChoices.AAP24)
 
+    # AAP versions that use the new API structure (2.5+)
+    MODERN_AAP_VERSIONS = [
+        ClusterVersionChoices.AAP25,
+        ClusterVersionChoices.AAP26,
+        ClusterVersionChoices.AAP27,
+    ]
+
     def __str__(self):
         return f'{self.protocol}://{self.address}:{self.port}'
 
@@ -88,7 +95,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def api_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
+        if self.aap_version in self.MODERN_AAP_VERSIONS:
             return f'/api/controller/v2'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'/api/v2'
@@ -97,7 +104,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def gui_base_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
+        if self.aap_version in self.MODERN_AAP_VERSIONS:
             return f'{self.base_url}/execution/'
         elif self.aap_version == ClusterVersionChoices.AAP24:
             return f'{self.base_url}/#/'
@@ -106,7 +113,7 @@ class Cluster(CreatUpdateModel):
 
     @property
     def oauth_token_url(self):
-        if self.aap_version in [ClusterVersionChoices.AAP25, ClusterVersionChoices.AAP26, ClusterVersionChoices.AAP27]:
+        if self.aap_version in self.MODERN_AAP_VERSIONS:
             return '/o/token/'
         elif self.aap_version in [ClusterVersionChoices.AAP24]:
             return '/api/o/token/'

--- a/src/backend/apps/clusters/schemas.py
+++ b/src/backend/apps/clusters/schemas.py
@@ -28,7 +28,7 @@ class ClusterSettings(FrozenModel):
 
 
 class ClusterSchema(ClusterSettings):
-    aap_version: Literal["AAP 2.6", "AAP 2.5", "AAP 2.4"] | None = None
+    aap_version: Literal["AAP 2.7", "AAP 2.6", "AAP 2.5", "AAP 2.4"] | None = None
     api_url: str
     base_url: str
 

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -699,6 +699,19 @@ class TestConnector:
         mocker.patch('requests.get', new=mocked_requests_get)
         assert connector.detect_aap_version() == ClusterVersionChoices.AAP26
 
+    def test_detect_aap_version_27(self, mocker, cluster):
+        """detect_aap_version should return AAP27 when the gateway returns version 2.7."""
+        def mocked_requests_get(*args, **kwargs):
+            headers = {
+                'Content-Type': 'application/json',
+                'X-Api-Product-Name': 'Red Hat Ansible Automation Platform',
+            }
+            return get_response(**{'headers': headers, 'data': {'version': '2.7'}})
+
+        connector = ApiConnector(cluster)
+        mocker.patch('requests.get', new=mocked_requests_get)
+        assert connector.detect_aap_version() == ClusterVersionChoices.AAP27
+
     def test_detect_aap_version_unknown_version_raises(self, mocker, cluster):
         """detect_aap_version should raise when the gateway responds with an unknown version."""
         def mocked_requests_get(*args, **kwargs):


### PR DESCRIPTION
Added AAP (Ansible Automation Platform) 2.7 support across the codebase:

Backend changes:
- Added AAP27 to ClusterVersionChoices enum in models.py
- Updated api_url, gui_base_url, oauth_token_url properties to handle AAP 2.7
- Updated schemas.py to include "AAP 2.7" in version Literal type
- Enhanced connector.py version detection to recognize AAP 2.7
- Created database migration 0025 to add AAP 2.7 as a valid choice

Documentation updates:
- Updated README.md to reference AAP v2.5, v2.6, v2.7
- Updated data sync architecture docs for version 2.7 support
- Updated database schema docs to include AAP 2.7

AAP 2.7 uses the same API endpoints as 2.5 and 2.6:
- API: /api/controller/v2
- GUI: /execution/
- OAuth: /o/token/

Draft: I need to test this, and need to setup AAP 2.7 first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ansible Automation Platform (AAP) version 2.7 with automatic version detection and configuration.

* **Documentation**
  * Updated README, setup instructions, and architecture documentation to reflect AAP 2.7 compatibility alongside existing AAP versions (2.4–2.6).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->