### PR TITLE
AAP-76208 Fix: Stop logging misleading job template deletion messages

### DIFF
--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -299,11 +299,17 @@ class ApiConnector:
                         )
                 response_data.append(result["id"])
         if sync_type == 'job_template':
+            skipped_count = 0
             for key, value in db_data.items():
-                logger.info(f"Deleting job template {value.name} with id {value.id}")
                 count = Job.objects.filter(job_template_id=value.id, cluster_id=value.cluster_id).count()
                 if count == 0:
+                    logger.info(f"Deleting job template {value.name} with id {value.id}")
                     value.delete()
+                else:
+                    skipped_count += 1
+
+            if skipped_count > 0:
+                logger.info(f"Skipped deletion of {skipped_count} templates deleted from AAP but DB retains them with job references")
 
     def ping(self, ping_url):
         logger.info(f'Pinging api {self.cluster.base_url}{ping_url}')

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -14,7 +14,7 @@ from backend.apps.clusters.connector import ApiConnector
 from backend.apps.clusters.encryption import decrypt_value
 from backend.apps.clusters.models import (
     ClusterVersionChoices, Cluster, Organization, JobTemplate,
-    ClusterSyncData, ClusterSyncStatus,
+    ClusterSyncData, ClusterSyncStatus, Job, JobTypeChoices, JobStatusChoices,
 )
 
 
@@ -230,6 +230,56 @@ class TestConnector:
         connector = ApiConnector(cluster)
         with pytest.raises(NotImplementedError):
             connector.sync_common(sync_type='foo')
+
+    def test_sync_job_templates_deletion_with_jobs(self, mocker, cluster, caplog):
+        """Test that templates deleted from AAP but with job references are skipped, not deleted."""
+        import logging
+
+        # Create templates in DB: one with jobs, one without
+        template_with_jobs = JobTemplate.objects.create(
+            name="Template With Jobs",
+            cluster=cluster,
+            external_id=100,
+            description="Has job references"
+        )
+        template_without_jobs = JobTemplate.objects.create(
+            name="Template Without Jobs",
+            cluster=cluster,
+            external_id=101,
+            description="No job references"
+        )
+
+        # Create a job referencing the first template
+        Job.objects.create(
+            type=JobTypeChoices.JOB,
+            name="Test Job",
+            job_template=template_with_jobs,
+            cluster=cluster,
+            external_id=999,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime(2025, 1, 1, 10, 0, 0, tzinfo=pytz.UTC),
+            finished=datetime(2025, 1, 1, 10, 5, 0, tzinfo=pytz.UTC),
+        )
+
+        # Mock API response - returns empty list (both templates deleted from AAP)
+        mock = mocker.patch('backend.apps.clusters.connector.ApiConnector.execute_get')
+        mock.side_effect = [[iter([])]]
+
+        connector = ApiConnector(cluster)
+
+        # Capture logs
+        with caplog.at_level(logging.INFO):
+            connector.sync_common(sync_type='job_template')
+
+        # Template without jobs should be deleted
+        assert not JobTemplate.objects.filter(external_id=101).exists()
+        assert "Deleting job template Template Without Jobs" in caplog.text
+
+        # Template with jobs should still exist (skipped)
+        assert JobTemplate.objects.filter(external_id=100).exists()
+
+        # Should log about skipped deletion
+        assert "Skipped deletion of 1 templates deleted from AAP but DB retains them with job references" in caplog.text
 
     def test_jobs(self, mocker, cluster):
         return_items = [{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]


### PR DESCRIPTION
## Summary

Fixes misleading "Deleting job template..." log spam when AAP templates are deleted but dashboard DB retains them with job references.

## Problem

The `sync_common()` function logged thousands of "Deleting job template..." messages every sync cycle (every 60 seconds) even though templates couldn't actually be deleted due to foreign key constraints from the jobs table.

**Observed behavior:**
- ~2,000 "Deleting..." log entries every 60 seconds
- None of the templates were actually deleted
- Log files grew rapidly with misleading information
- Example: 4,057 deletion log lines in 18 minutes (36 sync cycles)

**Scenario:**
- AAP templates were deleted or cleaned up (e.g., AAP reinstall, test data cleanup)
- Dashboard DB retained templates because jobs reference them
- Foreign key constraint prevents deletion but log still claimed "Deleting..."

## Solution

Move the log message after the count check and add a summary for skipped deletions:

- Only log INFO when templates are **actually deleted** (count == 0)
- Track skipped deletions in a counter
- Log one INFO summary per sync cycle if any templates were skipped

**Before:**
```python
logger.info(f"Deleting job template {value.name} with id {value.id}")
count = Job.objects.filter(job_template_id=value.id, cluster_id=value.cluster_id).count()
if count == 0:
    value.delete()
```

**After:**
```python
count = Job.objects.filter(job_template_id=value.id, cluster_id=value.cluster_id).count()
if count == 0:
    logger.info(f"Deleting job template {value.name} with id {value.id}")
    value.delete()
else:
    skipped_count += 1

if skipped_count > 0:
    logger.info(f"Skipped deletion of {skipped_count} templates deleted from AAP but DB retains them with job references")
```

## Impact

- **Before:** Thousands of misleading log entries per hour
- **After:** Only actual deletions logged individually, skipped deletions summarized in one line per sync

## Testing

Tested with scenario where ~2,000 templates exist in DB but not in AAP (from log analysis in bug-again/journal-3b.log).

## Files Changed

- `src/backend/apps/clusters/connector.py` - Fixed sync_common() logging logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of job template deletion when related jobs exist. The system now tracks and logs skipped deletions with a summary message for better visibility.

* **Tests**
  * Added test coverage for job template synchronization behavior with existing job references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->