### PR TITLE
conforma fix

### DIFF
--- a/.tekton/automation-reports-pull-request.yaml
+++ b/.tekton/automation-reports-pull-request.yaml
@@ -44,9 +44,9 @@ spec:
     - name: prefetch-input
       value: '[{"type": "npm", "path": "."}, {"type": "rpm", "path": "."}, {"type": "pip", "path": ".", "requirements_files": ["requirements-build.txt"], "requirements_build_files": ["requirements-build-tools.txt"]}]'
     - name: build-source-image
-      value: "false"
-    - name: skip-checks
       value: "true"
+    #- name: skip-checks
+    #  value: "true"
     - name: log-level
       value: info
     - name: enable-cache-proxy


### PR DESCRIPTION
Before, konflux conforma always failed for a PRs, and succeeded only after the merge.
Easy to forget, this makes testing a bit painful. 
In piture:
- Bottom 2 lines, commit 60abbf489a was PR to be merged into release-0.5 branch
- middle 2 lines, commit 31a8ccfa94 is release-0.5 branch after 60abbf489a got merged

With this modification, PRs also pass conforma check - top 2 lines, commit 00debb9
<img width="2323" height="633" alt="image" src="https://github.com/user-attachments/assets/e99a6f68-c66e-4b33-a0bc-9bd7a0f4a43b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to produce a source image by default.
  * Disabled a previously active check override so the pipeline now follows the standard validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->