### PR TITLE
[AAP-81383] - Handle renamed job templates and organizations during sync

### DIFF
--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -283,19 +283,27 @@ class ApiConnector:
                 else:
                     logger.info(f"Creating new {sync_type} {result['name']}")
                     if sync_type == 'job_template':
-                        JobTemplate.objects.create(
+                        obj, created = JobTemplate.objects.update_or_create(
                             cluster=self.cluster,
                             name=result["name"],
-                            description=result["description"],
-                            external_id=result["id"],
                             organization=organization,
+                            defaults={
+                                "description": result["description"],
+                                "external_id": result["id"],
+                            },
                         )
+                        if not created:
+                            # ponytail: Template existed under a different external_id (Controller
+                            # recreated with same name). Drop stale key so cleanup doesn't orphan it.
+                            db_data = {k: v for k, v in db_data.items() if v.pk != obj.pk}
                     elif sync_type == 'organization':
-                        Organization.objects.create(
+                        Organization.objects.update_or_create(
                             cluster=self.cluster,
                             name=result["name"],
-                            description=result["description"],
-                            external_id=result["id"],
+                            defaults={
+                                "description": result["description"],
+                                "external_id": result["id"],
+                            },
                         )
                 response_data.append(result["id"])
         if sync_type == 'job_template':

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -226,6 +226,25 @@ class TestConnector:
             for key, value in expected_obj.items():
                 assert getattr(db_data[i], key) == value
 
+    def test_sync_job_templates_stale_external_id(self, mocker, cluster):
+        """Template recreated in Controller with same name but new ID: row updated, not deleted."""
+        JobTemplate.objects.create(name="Stale Template", cluster=cluster, external_id=10)
+        api_result = [{"id": 99, "type": "job_template", "name": "Stale Template", "description": "updated"}]
+        mocker.patch('backend.apps.clusters.connector.ApiConnector.execute_get').side_effect = [[iter(api_result)]]
+        ApiConnector(cluster).sync_common(sync_type='job_template')
+        tmpl = JobTemplate.objects.get(cluster=cluster, name="Stale Template")
+        assert tmpl.external_id == 99
+        assert tmpl.description == "updated"
+
+    def test_sync_organizations_duplicate(self, mocker, cluster):
+        """Organization recreated in Controller with same name but new ID: row updated, no IntegrityError."""
+        Organization.objects.create(name="Stale Org", cluster=cluster, external_id=10)
+        api_result = [{"id": 99, "type": "organization", "name": "Stale Org", "description": "updated"}]
+        mocker.patch('backend.apps.clusters.connector.ApiConnector.execute_get').side_effect = [[iter(api_result)]]
+        ApiConnector(cluster).sync_common(sync_type='organization')
+        org = Organization.objects.get(cluster=cluster, name="Stale Org")
+        assert org.external_id == 99
+
     def test_sync_common_not_implemented(self, cluster):
         connector = ApiConnector(cluster)
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
When AAP deletes and recreates a resource with the same name but a new external ID, the sync would attempt to create a duplicate DB row rather than updating the existing one. This violated the unique constraint on (cluster, name, organization) and caused the sync task to fail.

Switch from create() to update_or_create() keyed on (cluster, name, organization) so that a changed external ID updates the existing row in place. For job templates, also purge the stale external_id key from the in-memory cleanup map to prevent the just-updated row from being incorrectly deleted at the end of the sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync behavior so existing job templates and organizations are updated in place when they reappear with the same name but a new identifier.
  * Prevented accidental removal or duplication during reconciliation by matching records more reliably.
  * Ensured related fields like description and external ID stay consistent without breaking the existing cleanup of missing templates.
* **Tests**
  * Added unit tests covering stale external IDs for job templates and duplicate handling for organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->