### PR TITLE
AAP-79315 Add custom CA certificate support for outbound TLS connections

### DIFF
--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/automationdashboard/tasks/facts.yml
@@ -99,9 +99,13 @@
     __task_cmd: /usr/bin/launch_dashboard_task.sh
     __task_env:
       SUPERVISOR_CONFIG_PATH: /etc/supervisord_task.conf
+      REQUESTS_CA_BUNDLE: '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+      SSL_CERT_FILE: '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
     __web_cmd: /usr/bin/launch_dashboard_web.sh
     __web_env:
       SUPERVISOR_CONFIG_PATH: /etc/supervisord_web.conf
+      REQUESTS_CA_BUNDLE: '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+      SSL_CERT_FILE: '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
 
 - name: Set facts for systemd services
   ansible.builtin.set_fact:

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/handlers/main.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/handlers/main.yml
@@ -1,14 +1,2 @@
 ---
-- name: Update CA trust
-  containers.podman.podman_container:
-    name: update-ca-trust
-    image: '{{ _images | first }}'
-    command: 'update-ca-trust'
-    detach: false
-    rm: true
-    log_driver: journald
-    user: root
-    volume:
-      - '{{ _ca_tls_dir }}/extracted:/etc/pki/ca-trust/extracted:z'
-      - '{{ _ca_tls_dir }}/ca.cert:/etc/pki/ca-trust/source/anchors/tls-aap.cert:ro,z'
 ...

--- a/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/tls.yml
+++ b/setup/collections/ansible_collections/ansible/containerized_installer/roles/common/tasks/tls.yml
@@ -3,6 +3,11 @@
   ansible.builtin.set_fact:
     _ca_tls_dir: '{{ ansible_user_dir }}/aap/tls'
 
+- name: Get CA certificate checksum before changes
+  ansible.builtin.stat:
+    path: '{{ _ca_tls_dir }}/ca.cert'
+  register: _ca_cert_before
+
 - name: Create the TLS CA directory
   ansible.builtin.file:
     path: '{{ _ca_tls_dir }}'
@@ -59,7 +64,6 @@
             privatekey_path: '{{ _ca_tls_dir }}/ca.key'
             provider: selfsigned
             mode: '0640'
-          notify: Update CA trust
 
     - name: Copy TLS CA files to other nodes
       block:
@@ -84,7 +88,6 @@
             dest: '{{ _ca_tls_dir }}/ca.cert'
             mode: '0640'
           run_once: false
-          notify: Update CA trust
 
         - name: Copy TLS CA key
           ansible.builtin.copy:
@@ -110,7 +113,6 @@
         dest: '{{ _ca_tls_dir }}/ca.cert'
         mode: '0640'
         remote_src: '{{ ca_tls_remote | default(false) }}'
-      notify: Update CA trust
 
     - name: Copy TLS CA key
       ansible.builtin.copy:
@@ -118,6 +120,39 @@
         dest: '{{ _ca_tls_dir }}/ca.key'
         mode: '0400'
         remote_src: '{{ ca_tls_remote | default(false) }}'
+
+- name: Get CA certificate checksum after changes
+  ansible.builtin.stat:
+    path: '{{ _ca_tls_dir }}/ca.cert'
+  register: _ca_cert_after
+
+- name: Set CA certificate changed fact
+  ansible.builtin.set_fact:
+    _ca_cert_changed: >-
+      {{ (_ca_cert_before.stat.checksum | default(''))
+         != (_ca_cert_after.stat.checksum | default('')) }}
+
+- name: Set volumes for updating the CA trust
+  ansible.builtin.set_fact:
+    _ca_volumes:
+      - '{{ _ca_tls_dir }}/extracted:/etc/pki/ca-trust/extracted:z'
+      - '{{ _ca_tls_dir }}/ca.cert:/etc/pki/ca-trust/source/anchors/tls-aap.cert:ro,z'
+
+- name: Copy extra TLS CA certificates
+  ansible.builtin.copy:
+    src: '{{ custom_ca_cert }}'
+    dest: '{{ _ca_tls_dir }}/custom.cert'
+    mode: '0640'
+    remote_src: '{{ ca_tls_remote | default(false) }}'
+  when: custom_ca_cert is defined
+
+- name: Add extra TLS CA certificate to volumes
+  ansible.builtin.set_fact:
+    _ca_volumes: '{{ _ca_volumes + _custom_ca }}'
+  vars:
+    _custom_ca:
+      - '{{ _ca_tls_dir }}/custom.cert:/etc/pki/ca-trust/source/anchors/tls-custom.cert:ro,z'
+  when: custom_ca_cert is defined
 
 - name: Create the PKI directories
   ansible.builtin.file:
@@ -129,4 +164,16 @@
     - java
     - pem
     - openssl
+
+- name: Update CA trust
+  containers.podman.podman_container:
+    name: update-ca-trust
+    image: '{{ _images | first }}'
+    command: 'update-ca-trust'
+    detach: false
+    entrypoint: ''
+    rm: true
+    log_driver: journald
+    user: root
+    volume: '{{ _ca_volumes }}'
 ...

--- a/setup/inventory.example
+++ b/setup/inventory.example
@@ -73,6 +73,11 @@ dashboard_pg_username=aapdashboard
 dashboard_pg_password=TODO
 dashboard_pg_database=aapdashboard
 
+# Custom CA certificate for verifying TLS connections to AAP.
+# Path to a PEM-format CA certificate file on the Ansible controller.
+# When set, the certificate is added to the container trust store.
+# custom_ca_cert=/path/to/custom-ca.pem
+
 bundle_install=false
 #
 # Relevant if bundle_install=false


### PR DESCRIPTION
## Summary
- Add `custom_ca_cert` inventory variable to supply a custom CA certificate (PEM) for trusting AAP servers with private/enterprise CAs
- Align `common/tasks/tls.yml` with the upstream AAP containerized installer pattern: inline `update-ca-trust` task with `_ca_volumes` fact, checksum tracking, and conditional custom cert mounting
- Set `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` unconditionally in dashboard container environments so the Python `requests` library uses the system trust store (which includes the custom CA)
- Remove the `Update CA trust` handler (replaced by inline task)

## Test plan
- [x] Run installer with `custom_ca_cert` set in inventory pointing to a real CA cert
- [x] Verify `~/aap/tls/custom.cert` is created on the managed host
- [x] Verify `REQUESTS_CA_BUNDLE` is set in containers: `podman exec automation-dashboard-task env | grep REQUESTS_CA_BUNDLE`
- [x] With `check_ssl=true` and `verify_ssl=true`, confirm authentication and data sync work against an AAP instance using the custom CA
- [x] Run installer without `custom_ca_cert` to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TLS handling for dashboard tasks and web processes by automatically using the trusted CA bundle.
  * Added support for an optional custom CA certificate when verifying secure connections.

* **Bug Fixes**
  * Updated certificate trust refresh behavior to run directly during TLS setup, making trust updates more reliable.
  * Removed an outdated trust-update step that could leave certificate changes unapplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

-----------

Manual test:
Inventory with `aap_auth_provider_check_ssl=true`, clusters.yaml with `verify_ssl=true`, both worked. CA cert - containirized AAP has it at  ~/aap/tls/extracted/pem/tls-ca-bundle.pem, the first entry.