### PR TITLE
fix: replace generic Exception raises with specific domain exception …

### DIFF
--- a/src/backend/apps/clusters/connector.py
+++ b/src/backend/apps/clusters/connector.py
@@ -18,6 +18,7 @@ from backend.apps.clusters.models import (
     Job,
     Organization, ClusterVersionChoices
 )
+from backend.apps.clusters.exceptions import InvalidClusterVersionError, UnsupportedProductError
 from backend.apps.clusters.schemas import ClusterSchema
 
 logger = logging.getLogger("automation_dashboard.clusters.connector")
@@ -189,7 +190,7 @@ class ApiConnector:
         logger.debug(f"Product name from headers: {product_name}")
         if product_name is None or product_name == "AWX":
             logger.error("Not supported product.")
-            raise Exception("Not supported product.")
+            raise UnsupportedProductError("Not supported product.")
         response = response.json()
         logger.debug(f"GET response JSON: {response}")
         return response
@@ -344,7 +345,7 @@ class ApiConnector:
                 return ClusterVersionChoices.AAP25
             else:
                 logger.error(f'Not valid version {response25["version"]} for cluster {self.cluster.base_url}.')
-                raise Exception(f'Not valid version {response25["version"]} for cluster {self.cluster.base_url}.')
+                raise InvalidClusterVersionError(f'Not valid version {response25["version"]} for cluster {self.cluster.base_url}.')
 
         logger.info(f'Checking if is AAP 2.4 at {self.cluster.base_url}')
         response24 = self.ping("/api/v2/ping/")
@@ -353,7 +354,7 @@ class ApiConnector:
             return ClusterVersionChoices.AAP24
 
         logger.error(f'Not valid version for cluster {self.cluster.base_url}.')
-        raise Exception(f'Not valid version for cluster {self.cluster.base_url}.')
+        raise InvalidClusterVersionError(f'Not valid version for cluster {self.cluster.base_url}.')
 
     def check_aap_version(self):
         logger.info("Checking AAP version for cluster.")

--- a/src/backend/apps/clusters/exceptions.py
+++ b/src/backend/apps/clusters/exceptions.py
@@ -1,0 +1,6 @@
+class UnsupportedProductError(Exception):
+    pass
+
+
+class InvalidClusterVersionError(Exception):
+    pass

--- a/src/backend/tests/unit/test_connector.py
+++ b/src/backend/tests/unit/test_connector.py
@@ -11,6 +11,7 @@ import time_machine
 from requests import Response
 
 from backend.apps.clusters.connector import ApiConnector
+from backend.apps.clusters.exceptions import InvalidClusterVersionError, UnsupportedProductError
 from backend.apps.clusters.encryption import decrypt_value
 from backend.apps.clusters.models import (
     ClusterVersionChoices, Cluster, Organization, JobTemplate,
@@ -75,7 +76,7 @@ class TestConnector:
 
         connector = ApiConnector(cluster)
         mocker.patch('requests.get', new=mocked_requests_get)
-        with pytest.raises(Exception) as e:
+        with pytest.raises(UnsupportedProductError) as e:
             connector.execute_get_one(f"{cluster.base_url}{cluster.api_url}/test_endpoint")
         assert str(e.value) == "Not supported product."
 
@@ -181,9 +182,9 @@ class TestConnector:
         assert Cluster.objects.first().aap_version == ClusterVersionChoices.AAP25
 
     def test_check_aap_version_fail(self, mocker, cluster):
-        mocker.patch('backend.apps.clusters.connector.ApiConnector.detect_aap_version', side_effect=Exception('Not valid version for cluster https://localhost:8000.'), new_callable=mocker.PropertyMock)
+        mocker.patch('backend.apps.clusters.connector.ApiConnector.detect_aap_version', side_effect=InvalidClusterVersionError('Not valid version for cluster https://localhost:8000.'), new_callable=mocker.PropertyMock)
         connector = ApiConnector(cluster)
-        with pytest.raises(Exception) as e:
+        with pytest.raises(InvalidClusterVersionError) as e:
             connector.check_aap_version()
         assert str(e.value) == "Not valid version for cluster https://localhost:8000."
 
@@ -773,7 +774,7 @@ class TestConnector:
 
         connector = ApiConnector(cluster)
         mocker.patch('requests.get', new=mocked_requests_get)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(InvalidClusterVersionError) as exc_info:
             connector.detect_aap_version()
         assert 'Not valid version' in str(exc_info.value)
 
@@ -784,7 +785,7 @@ class TestConnector:
             return_value=None,
         )
         connector = ApiConnector(cluster)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(InvalidClusterVersionError) as exc_info:
             connector.detect_aap_version()
         assert 'Not valid version' in str(exc_info.value)
 

--- a/src/backend/tests/unit/test_encryption.py
+++ b/src/backend/tests/unit/test_encryption.py
@@ -1,4 +1,6 @@
 import pytest
+from cryptography.fernet import InvalidToken
+
 from backend.apps.clusters import encryption
 
 
@@ -25,5 +27,5 @@ class TestEncryption:
         assert encrypted1 != encrypted2
 
     def test_decrypt_invalid_value_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(InvalidToken):
             encryption.decrypt_value(b"not_a_valid_encrypted_value")


### PR DESCRIPTION
Introduces two domain-specific exception classes (`UnsupportedProductError`, `InvalidClusterVersionError`) to replace bare `raise Exception(...) `calls in `ApiConnector`. Updates tests to assert against these specific types, and fixes `test_decrypt_invalid_value_raises` to catch `cryptography.fernet.InvalidToken` instead of the generic `Exception` base class. 

Resolves SonarQube findings on overly broad exception assertions.