### PR TITLE
Fix installer GHA: version naming and per-arch online installers

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -35,7 +35,20 @@ env:
   SELECTED_AAP_DASHBOARD_IMAGE: ${{ inputs.AAP_DASHBOARD_IMAGE || 'registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest' }}
 
 jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from branch name
+        id: extract
+        run: |
+          VERSION="${GITHUB_REF_NAME#release-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION (from branch: $GITHUB_REF_NAME)"
+
   bundled-installer:
+    needs: set-version
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -99,6 +112,7 @@ jobs:
           echo "Build configuration:"
           echo "  AAP_DASHBOARD_IMAGE: ${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}"
           echo "  INSTALLER_ARCH: ${{ matrix.installer_arch }}"
+          echo "  VERSION: ${{ needs.set-version.outputs.version }}"
           echo "  Branch: ${{ github.ref_name }}"
           echo "  Bundled installer: yes"
       - name: Build bundled installer
@@ -107,16 +121,17 @@ jobs:
           USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
           AAP_DASHBOARD_IMAGE=${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}
           INSTALLER_ARCH=${{ matrix.installer_arch }}
-          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ github.ref_name }}-${{ matrix.installer_arch }}.tar.gz"
+          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ needs.set-version.outputs.version }}-${{ matrix.installer_arch }}.tar.gz"
           setup/build_installer.sh
-      - name: Upload installer artifact
+      - name: Upload bundled installer
         uses: actions/upload-artifact@v4
         with:
-          name: ansible-automation-dashboard-containerized-setup-bundle-${{ github.ref_name }}-${{ matrix.installer_arch }}.tar.gz
-          path: setup/bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ github.ref_name }}-${{ matrix.installer_arch }}.tar.gz
-          retention-days: 31
+          name: bundled-installer-${{ matrix.installer_arch }}
+          path: setup/bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ needs.set-version.outputs.version }}-${{ matrix.installer_arch }}.tar.gz
+          retention-days: 1
 
   online-installer:
+    needs: set-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,16 +141,43 @@ jobs:
       - name: Print build configuration
         run: |
           echo "Build configuration:"
+          echo "  VERSION: ${{ needs.set-version.outputs.version }}"
           echo "  Branch: ${{ github.ref_name }}"
           echo "  Bundled installer: no"
       - name: Build online installer
         run: >
           AAP_DASHBOARD_BUNDLED_INSTALLER=0
-          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-${{ github.ref_name }}.tar.gz"
+          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}.tar.gz"
           setup/build_installer.sh
-      - name: Upload installer artifact
+      - name: Create per-arch copies
+        run: |
+          cd setup/bundle
+          BASE="ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}"
+          cp "${BASE}.tar.gz" "${BASE}-x86_64.tar.gz"
+          mv "${BASE}.tar.gz" "${BASE}-aarch64.tar.gz"
+      - name: Upload online installers
         uses: actions/upload-artifact@v4
         with:
-          name: ansible-automation-dashboard-containerized-setup-${{ github.ref_name }}.tar.gz
-          path: setup/bundle/ansible-automation-dashboard-containerized-setup-${{ github.ref_name }}.tar.gz
+          name: online-installers
+          path: |
+            setup/bundle/ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}-x86_64.tar.gz
+            setup/bundle/ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}-aarch64.tar.gz
+          retention-days: 1
+
+  collect-installers:
+    needs: [set-version, bundled-installer, online-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '{bundled-installer-*,online-installers}'
+          merge-multiple: true
+      - name: Print checksums
+        run: sha256sum *.tar.gz
+      - name: Upload combined installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ansible-automation-dashboard-containerized-installers-${{ needs.set-version.outputs.version }}
+          path: '*.tar.gz'
           retention-days: 31

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - name: Extract version from branch name
         id: extract
+        # For release-x.y branches this strips the prefix to get "x.y".
+        # For other branches (e.g. workflow_dispatch on a feature branch)
+        # the full branch name is used as-is, which is fine for testing.
         run: |
           VERSION="${GITHUB_REF_NAME#release-}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -62,27 +62,14 @@ jobs:
           - installer_arch: aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Log in to Red Hat Registry
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ vars.REGISTRY_REDHAT_IO_USERNAME }}
-          password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
-      - name: Log in to Stage Red Hat Registry
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: registry.stage.redhat.io
-          username: ${{ vars.REGISTRY_STAGE_REDHAT_IO_USERNAME }}
-          password: ${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}
-      - name: Log in to Quay.io Registry
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: quay.io
-          username: ${{ vars.REGISTRY_QUAY_IO_USERNAME }}
-          password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}
+      - name: Log in to container registries
+        run: |
+          podman login -u "${{ vars.REGISTRY_REDHAT_IO_USERNAME }}" -p "${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}" registry.redhat.io
+          podman login -u "${{ vars.REGISTRY_STAGE_REDHAT_IO_USERNAME }}" -p "${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}" registry.stage.redhat.io
+          podman login -u "${{ vars.REGISTRY_QUAY_IO_USERNAME }}" -p "${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}" quay.io
       - name: Prepare inventory
         run: |
           REGISTRY_URL_AAP_AUTOMATION_DASHBOARD=$(echo "${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}" | cut -d'/' -f1)
@@ -129,7 +116,7 @@ jobs:
           INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-bundle-${VERSION}-${{ matrix.installer_arch }}.tar.gz"
           setup/build_installer.sh
       - name: Upload bundled installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bundled-installer-${{ matrix.installer_arch }}
           path: setup/bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ needs.set-version.outputs.version }}-${{ matrix.installer_arch }}.tar.gz
@@ -142,7 +129,7 @@ jobs:
       VERSION: ${{ needs.set-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Print build configuration
@@ -163,7 +150,7 @@ jobs:
           cp "${BASE}.tar.gz" "${BASE}-x86_64.tar.gz"
           mv "${BASE}.tar.gz" "${BASE}-aarch64.tar.gz"
       - name: Upload online installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: online-installers
           path: |
@@ -176,14 +163,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: '{bundled-installer-*,online-installers}'
           merge-multiple: true
       - name: Print checksums
         run: sha256sum *.tar.gz
       - name: Upload combined installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ansible-automation-dashboard-containerized-installers-${{ needs.set-version.outputs.version }}
           path: '*.tar.gz'

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -50,6 +50,8 @@ jobs:
   bundled-installer:
     needs: set-version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.set-version.outputs.version }}
     strategy:
       matrix:
         include:
@@ -112,8 +114,8 @@ jobs:
           echo "Build configuration:"
           echo "  AAP_DASHBOARD_IMAGE: ${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}"
           echo "  INSTALLER_ARCH: ${{ matrix.installer_arch }}"
-          echo "  VERSION: ${{ needs.set-version.outputs.version }}"
-          echo "  Branch: ${{ github.ref_name }}"
+          echo "  VERSION: $VERSION"
+          echo "  Branch: $GITHUB_REF_NAME"
           echo "  Bundled installer: yes"
       - name: Build bundled installer
         run: >
@@ -121,7 +123,7 @@ jobs:
           USE_LOCAL_AUTOMATION_DASHBOARD_IMAGE=0
           AAP_DASHBOARD_IMAGE=${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}
           INSTALLER_ARCH=${{ matrix.installer_arch }}
-          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-bundle-${{ needs.set-version.outputs.version }}-${{ matrix.installer_arch }}.tar.gz"
+          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-bundle-${VERSION}-${{ matrix.installer_arch }}.tar.gz"
           setup/build_installer.sh
       - name: Upload bundled installer
         uses: actions/upload-artifact@v4
@@ -133,6 +135,8 @@ jobs:
   online-installer:
     needs: set-version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.set-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,18 +145,18 @@ jobs:
       - name: Print build configuration
         run: |
           echo "Build configuration:"
-          echo "  VERSION: ${{ needs.set-version.outputs.version }}"
-          echo "  Branch: ${{ github.ref_name }}"
+          echo "  VERSION: $VERSION"
+          echo "  Branch: $GITHUB_REF_NAME"
           echo "  Bundled installer: no"
       - name: Build online installer
         run: >
           AAP_DASHBOARD_BUNDLED_INSTALLER=0
-          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}.tar.gz"
+          INSTALLER_FILE="bundle/ansible-automation-dashboard-containerized-setup-${VERSION}.tar.gz"
           setup/build_installer.sh
       - name: Create per-arch copies
         run: |
           cd setup/bundle
-          BASE="ansible-automation-dashboard-containerized-setup-${{ needs.set-version.outputs.version }}"
+          BASE="ansible-automation-dashboard-containerized-setup-${VERSION}"
           cp "${BASE}.tar.gz" "${BASE}-x86_64.tar.gz"
           mv "${BASE}.tar.gz" "${BASE}-aarch64.tar.gz"
       - name: Upload online installers

--- a/docs/09-release-process.md
+++ b/docs/09-release-process.md
@@ -21,39 +21,9 @@ You need to adjust `inventory` to use images from quay.io.
 Also, quay.io is used only for testing images.
 Staging images are at registry.stage.redhat.io, and production images are at registry.redhat.io.
 
-The GHA currently runs only on x84_64 architecture.
-Hence only images for x84_64 are produced.
-Image for ARM aarch64 are produced only for production, using other automated build and release tools.
+The GHA builds both x86_64 and aarch64 architectures.
+The bundled installer is built separately for each architecture (it contains arch-specific container images).
+The online installer is arch-independent, but is produced with per-arch filenames for CDN distribution.
 
-## Tricks
-
-### Convert GHA created bundled installer from x86_64 to aarch64
-
-The only files that requires replacement are included container images.
-The ansible scripts, example inventory and other files are left unmodified.
-The steps below assume someone else already built aarch64 images for us.
-We need to:
-
-- download bundled installer (filename like `ansible-automation-dashboard-containerized-setup-bundle-0.1-x86_64.tar.gz`)
-- pull aarch64 container images
-- unpack .tar.gz installer
-- replace container images (also .tar.gz extension)
-- pack modified directory into new .tar.gz installer
-
-Shell commands:
-
-```
-podman pull --arch=aarch64 registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest
-podman pull --arch=aarch64 registry.redhat.io/rhel8/postgresql-15:latest
-podman pull --arch=aarch64 registry.redhat.io/rhel8/redis-6:latest
-
-rm -fr ansible-automation-dashboard-containerized-setup
-tar -xzvf ansible-automation-dashboard-containerized-setup-bundle-0.1-x86_64.tar.gz
-(
-    cd ansible-automation-dashboard-containerized-setup/bundle/images/
-    podman image save registry.redhat.io/ansible-automation-platform/automation-dashboard-rhel9:latest | pigz -9 > automation-dashboard-rhel9.tar.gz
-    podman image save registry.redhat.io/rhel8/postgresql-15:latest | pigz -9 > postgresql-15.tar.gz
-    podman image save registry.redhat.io/rhel8/redis-6:latest | pigz -9 > redis-6.tar.gz
-)
-tar czvf ansible-automation-dashboard-containerized-setup-bundle-0.1-aarch64---test.tar.gz ansible-automation-dashboard-containerized-setup/
-```
+All four installers are collected into a single GHA artifact named
+`ansible-automation-dashboard-containerized-installers-<version>`.


### PR DESCRIPTION
Goal: what GHA builds should be directly usable for errata-staging-sideloader. Before, we needed to rename files, from `release-a.b` to `a.b`. Also, we needed to unzip 3 files, now we have a single zip with all needed files.

## Summary
- Extract version from branch name by stripping `release-` prefix so installer filenames use `0.5` instead of `release-0.5`
- Build online installer once and copy to both arch names (x86_64, aarch64) since content is identical
- Collect all 4 installer `.tar.gz` files into a single GHA artifact (`ansible-automation-dashboard-containerized-installers-<version>`)
- Print sha256 checksums in the build log

## Test plan
- [x] Trigger workflow on a `release-*` branch and verify artifact filenames match expected pattern
- [x] Verify sha256 checksums of the two online installer files are identical
- [x] Verify the single combined artifact contains all 4 `.tar.gz` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Installer build artifacts now use the release version derived from the branch name, with improved clarity in per-architecture naming for bundled and online installers.
  * Online installer outputs are distributed as architecture-specific tarballs, then collected into a single versioned combined artifact.
  * Packaging/upload retention behavior was adjusted for the updated artifact flow.

* **Documentation**
  * Release process docs were updated to explain the x86_64 vs aarch64 build and packaging behavior for bundled and online installers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->