### PR TITLE
AAP-80898 Bundle Ansible Galaxy collections into installer

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -32,7 +32,6 @@ cd setup
 ansible --version  # 2.14.17, py3.9
 cp -i inventory.example inventory
 nano inventory
-ansible-galaxy collection install -r requirements.yml
 ansible-playbook -i inventory ansible.containerized_installer.dashboard_install
 ```
 
@@ -62,7 +61,6 @@ sudo dnf install git podman ansible-core
 cp -i setup/inventory.example setup/inventory
 # setup bundle_install, bundle_dir, registry_username, registry_password
 nano setup/inventory
-(cd setup; ansible-galaxy collection install -r requirements.yml)
 
 ./setup/build_installer.sh
 # ...
@@ -109,7 +107,6 @@ cd ansible-automation-dashboard-containerized-setup/
 
 cp -i inventory.example inventory
 nano inventory
-ansible-galaxy collection install -r requirements.yml
 ansible-playbook -i inventory ansible.containerized_installer.dashboard_install
 ```
 

--- a/setup/build_installer.sh
+++ b/setup/build_installer.sh
@@ -86,6 +86,7 @@ Build configuration:
   INSTALLER_ARCH=$INSTALLER_ARCH
 EOF
 cd setup/
+ansible-galaxy collection install -r requirements.yml -p collections/
 if [ "$AAP_DASHBOARD_BUNDLED_INSTALLER" == "1" ]
 then
   INSTALLER_FILE="${INSTALLER_FILE:-bundle/ansible-automation-dashboard-containerized-setup-bundle.tar.gz}"
@@ -108,7 +109,7 @@ EOF
 /bin/cp ../clusters.example.yaml ./
 FILES=""
 FILES+=" ansible.cfg "
-FILES+=" collections/ansible_collections/ansible/containerized_installer/ "
+FILES+=" collections/ "
 FILES+=" inventory.example "
 FILES+=" meta "
 FILES+=" README.md "

--- a/setup/build_installer.sh
+++ b/setup/build_installer.sh
@@ -64,6 +64,18 @@ function save_container_image() {
   /bin/rm -f bundle/images/*.tar  # keep only .tar.gz files
 }
 
+function check_inventory() {
+  # Note: ansible-inventory returns 0 even for invalid files, so we use grep.
+  if [ ! -f inventory ]; then
+    echo "ERROR: setup/inventory file not found. Copy inventory.example to inventory and configure it before building."
+    exit 1
+  fi
+  if ! grep -q '^\[automationdashboard\]' inventory; then
+    echo "ERROR: setup/inventory is not a valid inventory file (missing [automationdashboard] group)."
+    exit 1
+  fi
+}
+
 function adjust_inventory_example() {
   # The inventory.example for bundled installer should have "bundle_install=false" by default.
   if [ "$AAP_DASHBOARD_BUNDLED_INSTALLER" == "1" ]
@@ -86,6 +98,7 @@ Build configuration:
   INSTALLER_ARCH=$INSTALLER_ARCH
 EOF
 cd setup/
+check_inventory
 ansible-galaxy collection install -r requirements.yml -p collections/
 if [ "$AAP_DASHBOARD_BUNDLED_INSTALLER" == "1" ]
 then


### PR DESCRIPTION
## Summary
- The build script (`build_installer.sh`) now runs `ansible-galaxy collection install` at build time, installing the 4 required Galaxy collections (ansible.posix, community.crypto, community.postgresql, containers.podman) into `collections/`
- The tarball includes all collections, so users no longer need to run `ansible-galaxy collection install -r requirements.yml` manually after extracting
- Removed the manual `ansible-galaxy` step from all 3 sections in README.md (test installer, manual build, end-user install)

## Test plan
- [x] Build bundled installer and verify the 4 Galaxy collections are present in the tarball
- [x] Extract tarball on a clean host and run `ansible-playbook -i inventory ansible.containerized_installer.dashboard_install` without running `ansible-galaxy` first
- [x] Build online installer and verify collections are also included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundled installer packages now include the full set of required Ansible collection files, making installer artifacts more self-contained.

* **Documentation**
  * Updated setup instructions to remove the separate collection installation step from install and build workflows.

* **Bug Fixes**
  * Simplified installer usage so the bundled package can be built and run without an extra manual collection install step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->