### PR TITLE
AAP-81383 fix existing JobTemplates with null organization

### DIFF
--- a/src/backend/apps/clusters/migrations/0027_fix_null_org_job_templates.py
+++ b/src/backend/apps/clusters/migrations/0027_fix_null_org_job_templates.py
@@ -1,0 +1,88 @@
+from django.db import migrations, models
+
+
+def fix_null_org_job_templates(apps, schema_editor):
+    """Fix JobTemplate rows with organization=NULL.
+
+    For each null-org template, use the organization from its associated
+    jobs to set the correct organization. When jobs reference multiple
+    orgs, split into per-org templates and reassign job FKs. If a
+    correct-org template already exists (from connector sync), merge
+    jobs into it.
+
+    Corner cases:
+    1. No null-org templates: no-op.
+    2. Template with zero jobs: skipped (can't determine org).
+    3. All jobs have org=NULL: skipped (no data to infer from).
+    4. Jobs with mixed orgs + some org=NULL: org=NULL jobs stay on the
+       original template, which is kept (not deleted).
+    5. Single org: one new template created, jobs reassigned, original deleted.
+    6. Multiple orgs: per-org templates created, jobs split, original deleted.
+    7. Correct-org template already exists (connector synced it): jobs merged
+       into existing template, no new template created.
+    8. Multiple null-org templates with same name (NULL != NULL in unique
+       constraints): each processed independently; second may merge into
+       template created by the first.
+    9. external_id collision: existing-template check covers both unique
+       constraints (cluster, name, org) and (cluster, external_id, org).
+    10. Idempotent: second run finds no null-org templates, no-op.
+    """
+    JobTemplate = apps.get_model('clusters', 'JobTemplate')
+    Job = apps.get_model('clusters', 'Job')
+
+    for tmpl in JobTemplate.objects.filter(organization__isnull=True):
+        org_ids = list(
+            Job.objects.filter(job_template=tmpl, organization__isnull=False)
+            .values_list('organization_id', flat=True)
+            .distinct()
+        )
+
+        if len(org_ids) == 0:
+            continue
+
+        for org_id in org_ids:
+            # Check both unique constraints: (cluster, name, org) and (cluster, external_id, org)
+            existing = JobTemplate.objects.filter(
+                cluster=tmpl.cluster, organization_id=org_id,
+            ).filter(
+                models.Q(name=tmpl.name) | models.Q(external_id=tmpl.external_id)
+            ).first()
+
+            if existing:
+                Job.objects.filter(
+                    job_template=tmpl, organization_id=org_id,
+                ).update(job_template=existing)
+            else:
+                new_tmpl = JobTemplate.objects.create(
+                    cluster=tmpl.cluster,
+                    external_id=tmpl.external_id,
+                    name=tmpl.name,
+                    description=tmpl.description,
+                    organization_id=org_id,
+                    time_taken_manually_execute_minutes=tmpl.time_taken_manually_execute_minutes,
+                    time_taken_create_automation_minutes=tmpl.time_taken_create_automation_minutes,
+                )
+                Job.objects.filter(
+                    job_template=tmpl, organization_id=org_id,
+                ).update(job_template=new_tmpl)
+
+        # Defensive: keep template if jobs with org=NULL still reference it.
+        # In practice AAP always sets organization on jobs, so this
+        # branch is unlikely to be reached.
+        if not Job.objects.filter(job_template=tmpl).exists():
+            tmpl.delete()
+
+
+def reverse_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clusters', '0026_alter_subscriptioncost_monthly_subscription_cost'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_null_org_job_templates, reverse_noop),
+    ]

--- a/src/backend/apps/clusters/models.py
+++ b/src/backend/apps/clusters/models.py
@@ -506,6 +506,66 @@ class JobTemplate(NameDescriptionModel):
     def __str__(self):
         return f"{self.organization}:{self.name}"
 
+    @classmethod
+    def create_or_update(cls, cluster: Cluster, external_id: int, **kwargs):
+        """Override BaseModel to include organization in all lookups.
+
+        JobTemplate unique constraints are (cluster, external_id, organization)
+        and (cluster, name, organization), so organization must be part of
+        every lookup to avoid matching templates from a different org.
+        """
+        from django.db import IntegrityError
+
+        name = kwargs.pop('name', None)
+        organization = kwargs.pop('organization', None)
+
+        if external_id > 0:
+            try:
+                model = cls.objects.get(
+                    cluster=cluster, external_id=external_id,
+                    organization=organization,
+                )
+                for key, value in kwargs.items():
+                    setattr(model, key, value)
+                model.name = name
+                model.save()
+                return model
+            except cls.DoesNotExist:
+                try:
+                    model, created = cls.objects.update_or_create(
+                        name=name, cluster=cluster, organization=organization,
+                        defaults={**kwargs, 'external_id': external_id},
+                    )
+                    return model
+                except IntegrityError:
+                    queryset = cls.objects.filter(
+                        cluster=cluster, external_id=external_id,
+                        organization=organization,
+                    )
+                    queryset.update(name=name, **kwargs)
+                    return queryset.get()
+        else:
+            max_retries = 5
+            for retry in range(max_retries):
+                _external_id = cls._compute_negative_external_id()
+                try:
+                    model, created = cls.objects.get_or_create(
+                        name=name, cluster=cluster, organization=organization,
+                        defaults={**kwargs, 'external_id': _external_id},
+                    )
+                    return model
+                except IntegrityError as e:
+                    try:
+                        queryset = cls.objects.filter(
+                            name=name, cluster=cluster,
+                            organization=organization,
+                        )
+                        queryset.update(**kwargs)
+                        return queryset.get()
+                    except cls.DoesNotExist:
+                        if retry == max_retries - 1:
+                            raise e
+
 
 class AAPUser(BaseModel):
     name = models.CharField(max_length=255)

--- a/src/backend/apps/clusters/parser.py
+++ b/src/backend/apps/clusters/parser.py
@@ -73,6 +73,7 @@ class DataParser:
             external_id=external_job_template.id if external_job_template else -1,
             name=external_job_template.name if external_job_template else self.data.name,
             description=external_job_template.description if external_job_template else self.data.description,
+            organization=self.organization,
         )
         job_count = Job.objects.filter(job_template=job_template).count()
         logger.debug(f"Job count for template: {job_count}")
@@ -234,7 +235,7 @@ class DataParser:
             logger.warning("No data to parse.")
             return
 
-        organization = self.organization
+        organization = self.organization # todo?
         job_template = self.job_template
         launched_by = self.launched_by
         inventory = self.inventory

--- a/src/backend/tests/unit/test_null_org_migration.py
+++ b/src/backend/tests/unit/test_null_org_migration.py
@@ -1,0 +1,208 @@
+"""
+Test DB migration that fixes null-org templates.
+
+Sets up the buggy state directly via ORM (no run_sync/run_parse),
+then verifies the migration produces correct state.
+
+AAP 2.6 API response for /api/controller/v2/jobs/<id>/ — template EXISTS:
+
+    "summary_fields": {
+        "organization": {"id": 1, "name": "Default", "description": "..."},
+        "job_template": {"id": 11, "name": "jobtemplate2-org1", "description": "..."},
+        ...
+    },
+    "job_template": 11,
+
+AAP 2.6 API response for /api/controller/v2/jobs/<id>/ — template DELETED:
+
+    "summary_fields": {
+        "organization": {"id": 2, "name": "org2", "description": "org2-desc"},
+        // job_template key is ABSENT (not null, entirely missing)
+        ...
+    },
+    "job_template": null,
+
+When job_template is absent from summary_fields, Pydantic defaults to None.
+The parser then falls back to external_id=-1 and uses the job's own name.
+"""
+import importlib
+
+import pytest
+from django.apps import apps as django_apps
+
+from backend.apps.clusters.models import (
+    JobTemplate, Job, Organization, AAPUser,
+)
+
+_migration = importlib.import_module(
+    "backend.apps.clusters.migrations.0027_fix_null_org_job_templates"
+)
+fix_null_org_job_templates = _migration.fix_null_org_job_templates
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+class TestNullOrgTemplateMigration:
+
+    @staticmethod
+    def _create_buggy_state(cluster, template_ext_id):
+        org_a = Organization.objects.create(
+            cluster=cluster, external_id=100, name="Org A", description="",
+        )
+        org_b = Organization.objects.create(
+            cluster=cluster, external_id=200, name="Org B", description="",
+        )
+        tmpl = JobTemplate.objects.create(
+            cluster=cluster, external_id=template_ext_id, name="Deploy",
+            description="", organization=None,
+        )
+        user = AAPUser.objects.create(
+            cluster=cluster, external_id=1, name="admin", type="user",
+        )
+        job_defaults = dict(
+            cluster=cluster, job_template=tmpl, launched_by=user,
+            status="successful", job_type="run", launch_type="manual",
+            failed=False, elapsed=300,
+        )
+        j1 = Job.objects.create(
+            external_id=1, name="Deploy", organization=org_a, **job_defaults,
+        )
+        j2 = Job.objects.create(
+            external_id=2, name="Deploy", organization=org_a, **job_defaults,
+        )
+        j3 = Job.objects.create(
+            external_id=3, name="Deploy", organization=org_b, **job_defaults,
+        )
+        return {"org_a": org_a, "org_b": org_b, "tmpl": tmpl,
+                "jobs": [j1, j2, j3]}
+
+    @pytest.fixture
+    def buggy_state_deleted_between_syncs(self, cluster):
+        """Template deleted between sync cycles.
+
+        Job data was fetched while template existed, so parser gets
+        positive ext_id. Last-parsed job's ext_id wins (20). See
+        _create_or_update_positive_id fallback in 5401a27c.
+        """
+        return self._create_buggy_state(cluster, template_ext_id=20)
+
+    @pytest.fixture
+    def buggy_state_never_synced(self, cluster):
+        """Template deleted from AAP before first sync.
+
+        AAP strips summary_fields.job_template from the job response,
+        so parser gets external_id=-1 via the negative-id path.
+        """
+        return self._create_buggy_state(cluster, template_ext_id=-1)
+
+    def test_precondition_deleted_between_syncs(self, cluster, buggy_state_deleted_between_syncs):
+        """Verify buggy state: template ext_id=20, org=NULL."""
+        state = buggy_state_deleted_between_syncs
+        self._assert_precondition(cluster, state, expected_ext_id=20)
+
+    def test_precondition_never_synced(self, cluster, buggy_state_never_synced):
+        """Verify buggy state: template ext_id=-1, org=NULL."""
+        state = buggy_state_never_synced
+        self._assert_precondition(cluster, state, expected_ext_id=-1)
+
+    def _assert_precondition(self, cluster, state, expected_ext_id):
+        org_a, org_b, tmpl = state["org_a"], state["org_b"], state["tmpl"]
+
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 1
+        assert Job.objects.filter(cluster=cluster).count() == 3
+
+        assert tmpl.organization is None
+        assert tmpl.name == "Deploy"
+        assert tmpl.external_id == expected_ext_id
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        for job in jobs:
+            assert job.job_template == tmpl
+            assert job.job_template.organization is None
+
+        assert jobs[0].organization == org_a
+        assert jobs[1].organization == org_a
+        assert jobs[2].organization == org_b
+
+    def test_migration_fixes_deleted_between_syncs(self, cluster, buggy_state_deleted_between_syncs):
+        """Placeholder: template deleted between sync cycles, then parsed."""
+        state = buggy_state_deleted_between_syncs
+        org_a, org_b, tmpl = state["org_a"], state["org_b"], state["tmpl"]
+
+        # Pre-migration: 1 template with org=NULL, all jobs point to it
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 1
+        assert Job.objects.filter(cluster=cluster).count() == 3
+        assert tmpl.organization is None
+        assert tmpl.external_id == 20
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        for job in jobs:
+            assert job.job_template == tmpl
+        assert jobs[0].organization == org_a
+        assert jobs[1].organization == org_a
+        assert jobs[2].organization == org_b
+
+        fix_null_org_job_templates(django_apps, None)
+
+        # Post-migration: 2 templates with correct orgs, null-org template deleted
+        assert JobTemplate.objects.filter(cluster=cluster, organization__isnull=True).count() == 0
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 2
+
+        t_a = JobTemplate.objects.get(cluster=cluster, name="Deploy", organization=org_a)
+        t_b = JobTemplate.objects.get(cluster=cluster, name="Deploy", organization=org_b)
+        assert t_a.name == "Deploy"
+        assert t_b.name == "Deploy"
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs.count() == 3
+        assert jobs[0].job_template == t_a
+        assert jobs[0].organization == org_a
+        assert jobs[0].job_template.organization == org_a
+
+        assert jobs[1].job_template == t_a
+        assert jobs[1].organization == org_a
+        assert jobs[1].job_template.organization == org_a
+
+        assert jobs[2].job_template == t_b
+        assert jobs[2].organization == org_b
+        assert jobs[2].job_template.organization == org_b
+
+    def test_migration_fixes_never_synced(self, cluster, buggy_state_never_synced):
+        """Template deleted from AAP before first sync."""
+        state = buggy_state_never_synced
+        org_a, org_b, tmpl = state["org_a"], state["org_b"], state["tmpl"]
+
+        # Pre-migration: 1 template with org=NULL, ext_id=-1
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 1
+        assert Job.objects.filter(cluster=cluster).count() == 3
+        assert tmpl.organization is None
+        assert tmpl.external_id == -1
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        for job in jobs:
+            assert job.job_template == tmpl
+        assert jobs[0].organization == org_a
+        assert jobs[1].organization == org_a
+        assert jobs[2].organization == org_b
+
+        fix_null_org_job_templates(django_apps, None)
+
+        # Post-migration: same expected state as deleted_between_syncs
+        assert JobTemplate.objects.filter(cluster=cluster, organization__isnull=True).count() == 0
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 2
+
+        t_a = JobTemplate.objects.get(cluster=cluster, name="Deploy", organization=org_a)
+        t_b = JobTemplate.objects.get(cluster=cluster, name="Deploy", organization=org_b)
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs.count() == 3
+        assert jobs[0].job_template == t_a
+        assert jobs[0].organization == org_a
+        assert jobs[0].job_template.organization == org_a
+
+        assert jobs[1].job_template == t_a
+        assert jobs[1].organization == org_a
+
+        assert jobs[2].job_template == t_b
+        assert jobs[2].organization == org_b
+        assert jobs[2].job_template.organization == org_b

--- a/src/backend/tests/unit/test_null_org_template.py
+++ b/src/backend/tests/unit/test_null_org_template.py
@@ -1,0 +1,295 @@
+"""
+Reproduce the null-organization bug on JobTemplate.
+
+When templates are deleted from AAP between sync cycles, the connector's
+cleanup removes them from the DB (zero job references because parse hasn't
+run yet). When parse finally runs, it recreates templates via
+JobTemplate.create_or_update WITHOUT passing organization, producing rows
+with organization=NULL.
+"""
+import pytest
+
+from backend.apps.clusters.connector import ApiConnector
+from backend.apps.clusters.models import (
+    ClusterSyncData, JobTemplate, Job, Organization,
+)
+from backend.apps.clusters.parser import DataParser
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+API_ORGS = [
+    {"id": 100, "type": "organization", "name": "Org A", "description": ""},
+    {"id": 200, "type": "organization", "name": "Org B", "description": ""},
+]
+
+API_TEMPLATES = [
+    {"id": 10, "type": "job_template", "name": "Deploy",
+     "description": "", "summary_fields": {"organization": {"id": 100}}},
+    {"id": 20, "type": "job_template", "name": "Deploy",
+     "description": "", "summary_fields": {"organization": {"id": 200}}},
+]
+
+
+def _make_job(job_id, template_id, template_name, org_id, org_name):
+    return {
+        "id": job_id,
+        "type": "job",
+        "name": template_name,
+        "description": "",
+        "launched_by": {"id": 1, "name": "admin", "type": "user"},
+        "summary_fields": {
+            "organization": {"id": org_id, "name": org_name, "description": ""},
+            "job_template": {"id": template_id, "name": template_name, "description": ""},
+            "inventory": None,
+            "execution_environment": None,
+            "instance_group": None,
+            "labels": {"count": 0, "results": []},
+            "project": None,
+        },
+        "started": "2026-07-01T10:00:00Z",
+        "finished": "2026-07-01T10:05:00Z",
+        "created": "2026-07-01T10:00:00Z",
+        "modified": "2026-07-01T10:05:00Z",
+        "elapsed": 300.0,
+        "failed": False,
+        "status": "successful",
+        "job_type": "run",
+        "launch_type": "manual",
+    }
+
+
+def _make_job_deleted_template(job_id, template_name, org_id, org_name):
+    """Job whose template was deleted from AAP.
+
+    AAP omits job_template from summary_fields entirely (not null, absent).
+    Pydantic defaults the missing field to None.
+    """
+    job = _make_job(job_id, None, template_name, org_id, org_name)
+    del job["summary_fields"]["job_template"]
+    return job
+
+
+API_JOBS = [
+    _make_job(1, 10, "Deploy", 100, "Org A"),
+    _make_job(2, 10, "Deploy", 100, "Org A"),
+    _make_job(3, 20, "Deploy", 200, "Org B"),
+]
+
+# Jobs where AAP already deleted the template — job_template is None
+API_JOBS_DELETED_TEMPLATE = [
+    _make_job_deleted_template(1, "Deploy", 100, "Org A"),
+    _make_job_deleted_template(2, "Deploy", 100, "Org A"),
+    _make_job_deleted_template(3, "Deploy", 200, "Org B"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors dbg_direct_sync / dbg_direct_parse
+# ---------------------------------------------------------------------------
+
+def run_sync(cluster, mocker, api_orgs, api_templates, api_jobs):
+    """Run sync_common(org) + sync_common(job_template) + sync_jobs, fully mocked."""
+    mock_get = mocker.patch(
+        'backend.apps.clusters.connector.ApiConnector.execute_get',
+    )
+    mock_get.side_effect = [
+        [iter(api_orgs)],
+        [iter(api_templates)],
+    ]
+
+    connector = ApiConnector(cluster, managed=True,
+                             since="2026-07-01T00:00:00+00:00",
+                             until="2026-07-02T00:00:00+00:00")
+    connector.sync_common('organization')
+    connector.sync_common('job_template')
+
+    mocker.patch(
+        'backend.apps.clusters.connector.ApiConnector.jobs',
+        return_value=api_jobs,
+        new_callable=mocker.PropertyMock,
+    )
+    mocker.patch(
+        'backend.apps.clusters.connector.ApiConnector.job_host_summaries',
+        return_value=iter([]),
+    )
+    connector.sync_jobs()
+
+    mocker.stopall()
+
+
+def run_parse(cluster):
+    """Parse all pending ClusterSyncData records, like dbg_direct_parse."""
+    for csd in ClusterSyncData.objects.filter(cluster=cluster).order_by('id'):
+        DataParser(csd.id).parse()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+class TestNullOrgTemplate:
+
+    def test_normal_flow(self, mocker, cluster):
+        """Sync then parse: templates get correct organization."""
+        run_sync(cluster, mocker, API_ORGS, API_TEMPLATES, API_JOBS)
+        run_parse(cluster)
+
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        org_a = Organization.objects.get(cluster=cluster, external_id=100)
+        org_b = Organization.objects.get(cluster=cluster, external_id=200)
+
+        templates = JobTemplate.objects.filter(cluster=cluster).order_by('external_id')
+        assert templates.count() == 2
+        t10 = templates.get(external_id=10)
+        t20 = templates.get(external_id=20)
+        assert t10.organization == org_a
+        assert t20.organization == org_b
+        assert t10.name == "Deploy"
+        assert t20.name == "Deploy"
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs.count() == 3
+        j1, j2, j3 = jobs[0], jobs[1], jobs[2]
+
+        assert j1.organization == org_a
+        assert j1.job_template == t10
+        assert j1.job_template.organization == org_a
+
+        assert j2.organization == org_a
+        assert j2.job_template == t10
+        assert j2.job_template.organization == org_a
+
+        assert j3.organization == org_b
+        assert j3.job_template == t20
+        assert j3.job_template.organization == org_b
+
+    def test_template_deleted_before_parse(self, mocker, cluster):
+        """Bug: sync twice (template deleted in AAP), then parse → org=NULL."""
+        # 1st sync: templates + jobs synced, parse jobs queued
+        run_sync(cluster, mocker, API_ORGS, API_TEMPLATES, API_JOBS)
+
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 2
+        assert ClusterSyncData.objects.filter(cluster=cluster).count() == 3
+
+        # 2nd sync: templates gone from AAP, cleanup deletes them (0 jobs)
+        run_sync(cluster, mocker, API_ORGS, [], [])
+
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 0
+
+        # Parse: recreates templates from job data WITHOUT organization
+        run_parse(cluster)
+
+        org_a = Organization.objects.get(cluster=cluster, external_id=100)
+        org_b = Organization.objects.get(cluster=cluster, external_id=200)
+
+        # Bug: only 1 template created (both org's jobs collapse into one
+        # because create_or_update doesn't pass org, and update_or_create
+        # matches by (cluster, name) — last write wins on external_id)
+        templates = JobTemplate.objects.filter(cluster=cluster)
+        assert templates.count() == 1
+
+        tmpl = templates.first()
+        assert tmpl.organization is None, "Bug: template has no organization"
+        assert tmpl.name == "Deploy"
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs.count() == 3
+
+        # All 3 jobs point to the same org-less template
+        for job in jobs:
+            assert job.job_template == tmpl
+            assert job.job_template.organization is None
+
+        # But jobs themselves have correct organizations
+        assert jobs[0].organization == org_a
+        assert jobs[1].organization == org_a
+        assert jobs[2].organization == org_b
+
+        # The mismatch: job.organization != job.job_template.organization
+        for job in jobs:
+            assert job.organization != job.job_template.organization
+
+    def test_template_deleted_after_parse(self, mocker, cluster):
+        """No bug: sync, parse (creates jobs), then sync again — templates kept."""
+        # 1st sync + parse: templates have jobs
+        run_sync(cluster, mocker, API_ORGS, API_TEMPLATES, API_JOBS)
+        run_parse(cluster)
+
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert Job.objects.filter(cluster=cluster).count() == 3
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 2
+
+        org_a = Organization.objects.get(cluster=cluster, external_id=100)
+        org_b = Organization.objects.get(cluster=cluster, external_id=200)
+
+        # 2nd sync: templates gone from AAP, but cleanup skips (have jobs)
+        run_sync(cluster, mocker, API_ORGS, [], [])
+
+        templates = JobTemplate.objects.filter(cluster=cluster).order_by('external_id')
+        assert templates.count() == 2
+
+        t10 = templates.get(external_id=10)
+        t20 = templates.get(external_id=20)
+        assert t10.organization == org_a
+        assert t20.organization == org_b
+
+        # Jobs still have correct relationships
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs[0].job_template == t10
+        assert jobs[0].organization == org_a
+        assert jobs[0].job_template.organization == org_a
+
+        assert jobs[1].job_template == t10
+        assert jobs[1].organization == org_a
+        assert jobs[1].job_template.organization == org_a
+
+        assert jobs[2].job_template == t20
+        assert jobs[2].organization == org_b
+        assert jobs[2].job_template.organization == org_b
+
+    def test_template_never_synced(self, mocker, cluster):
+        """Bug: template deleted from AAP before first sync, only jobs exist.
+
+        AAP strips summary_fields.job_template from the job response when
+        the template is deleted, so parser gets job_template=None and falls
+        back to external_id=-1 with the job's own name.
+        """
+        # Sync: orgs exist, templates already deleted, jobs have job_template=None
+        run_sync(cluster, mocker, API_ORGS, [], API_JOBS_DELETED_TEMPLATE)
+
+        assert Organization.objects.filter(cluster=cluster).count() == 2
+        assert JobTemplate.objects.filter(cluster=cluster).count() == 0
+        assert ClusterSyncData.objects.filter(cluster=cluster).count() == 3
+
+        # Parse: creates template with ext_id=-1 and organization=NULL
+        run_parse(cluster)
+
+        org_a = Organization.objects.get(cluster=cluster, external_id=100)
+        org_b = Organization.objects.get(cluster=cluster, external_id=200)
+
+        templates = JobTemplate.objects.filter(cluster=cluster)
+        assert templates.count() == 1
+
+        tmpl = templates.first()
+        assert tmpl.organization is None, "Bug: template has no organization"
+        assert tmpl.name == "Deploy"
+        assert tmpl.external_id == -1
+
+        jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
+        assert jobs.count() == 3
+
+        for job in jobs:
+            assert job.job_template == tmpl
+            assert job.job_template.organization is None
+
+        assert jobs[0].organization == org_a
+        assert jobs[1].organization == org_a
+        assert jobs[2].organization == org_b
+
+        for job in jobs:
+            assert job.organization != job.job_template.organization

--- a/src/backend/tests/unit/test_null_org_template.py
+++ b/src/backend/tests/unit/test_null_org_template.py
@@ -168,7 +168,7 @@ class TestNullOrgTemplate:
         assert j3.job_template.organization == org_b
 
     def test_template_deleted_before_parse(self, mocker, cluster):
-        """Bug: sync twice (template deleted in AAP), then parse → org=NULL."""
+        """Sync twice (template deleted in AAP), then parse → templates recreated with correct org."""
         # 1st sync: templates + jobs synced, parse jobs queued
         run_sync(cluster, mocker, API_ORGS, API_TEMPLATES, API_JOBS)
 
@@ -181,38 +181,35 @@ class TestNullOrgTemplate:
 
         assert JobTemplate.objects.filter(cluster=cluster).count() == 0
 
-        # Parse: recreates templates from job data WITHOUT organization
+        # Parse: recreates templates with correct organization
         run_parse(cluster)
 
         org_a = Organization.objects.get(cluster=cluster, external_id=100)
         org_b = Organization.objects.get(cluster=cluster, external_id=200)
 
-        # Bug: only 1 template created (both org's jobs collapse into one
-        # because create_or_update doesn't pass org, and update_or_create
-        # matches by (cluster, name) — last write wins on external_id)
         templates = JobTemplate.objects.filter(cluster=cluster)
-        assert templates.count() == 1
+        assert templates.count() == 2
+        assert templates.filter(organization__isnull=True).count() == 0
 
-        tmpl = templates.first()
-        assert tmpl.organization is None, "Bug: template has no organization"
-        assert tmpl.name == "Deploy"
+        t_a = templates.get(organization=org_a)
+        t_b = templates.get(organization=org_b)
+        assert t_a.name == "Deploy"
+        assert t_b.name == "Deploy"
 
         jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
         assert jobs.count() == 3
 
-        # All 3 jobs point to the same org-less template
-        for job in jobs:
-            assert job.job_template == tmpl
-            assert job.job_template.organization is None
-
-        # But jobs themselves have correct organizations
+        assert jobs[0].job_template == t_a
         assert jobs[0].organization == org_a
-        assert jobs[1].organization == org_a
-        assert jobs[2].organization == org_b
+        assert jobs[0].job_template.organization == org_a
 
-        # The mismatch: job.organization != job.job_template.organization
-        for job in jobs:
-            assert job.organization != job.job_template.organization
+        assert jobs[1].job_template == t_a
+        assert jobs[1].organization == org_a
+        assert jobs[1].job_template.organization == org_a
+
+        assert jobs[2].job_template == t_b
+        assert jobs[2].organization == org_b
+        assert jobs[2].job_template.organization == org_b
 
     def test_template_deleted_after_parse(self, mocker, cluster):
         """No bug: sync, parse (creates jobs), then sync again — templates kept."""
@@ -253,11 +250,12 @@ class TestNullOrgTemplate:
         assert jobs[2].job_template.organization == org_b
 
     def test_template_never_synced(self, mocker, cluster):
-        """Bug: template deleted from AAP before first sync, only jobs exist.
+        """Template deleted from AAP before first sync, only jobs exist.
 
         AAP strips summary_fields.job_template from the job response when
         the template is deleted, so parser gets job_template=None and falls
-        back to external_id=-1 with the job's own name.
+        back to external_id=-1 with the job's own name. Parser now sets
+        organization correctly from the job's summary_fields.
         """
         # Sync: orgs exist, templates already deleted, jobs have job_template=None
         run_sync(cluster, mocker, API_ORGS, [], API_JOBS_DELETED_TEMPLATE)
@@ -266,30 +264,34 @@ class TestNullOrgTemplate:
         assert JobTemplate.objects.filter(cluster=cluster).count() == 0
         assert ClusterSyncData.objects.filter(cluster=cluster).count() == 3
 
-        # Parse: creates template with ext_id=-1 and organization=NULL
+        # Parse: creates per-org templates with correct organization
         run_parse(cluster)
 
         org_a = Organization.objects.get(cluster=cluster, external_id=100)
         org_b = Organization.objects.get(cluster=cluster, external_id=200)
 
         templates = JobTemplate.objects.filter(cluster=cluster)
-        assert templates.count() == 1
+        assert templates.count() == 2
+        assert templates.filter(organization__isnull=True).count() == 0
 
-        tmpl = templates.first()
-        assert tmpl.organization is None, "Bug: template has no organization"
-        assert tmpl.name == "Deploy"
-        assert tmpl.external_id == -1
+        t_a = templates.get(organization=org_a)
+        t_b = templates.get(organization=org_b)
+        assert t_a.name == "Deploy"
+        assert t_b.name == "Deploy"
+        assert t_a.external_id < 0
+        assert t_b.external_id < 0
 
         jobs = Job.objects.filter(cluster=cluster).order_by('external_id')
         assert jobs.count() == 3
 
-        for job in jobs:
-            assert job.job_template == tmpl
-            assert job.job_template.organization is None
-
+        assert jobs[0].job_template == t_a
         assert jobs[0].organization == org_a
-        assert jobs[1].organization == org_a
-        assert jobs[2].organization == org_b
+        assert jobs[0].job_template.organization == org_a
 
-        for job in jobs:
-            assert job.organization != job.job_template.organization
+        assert jobs[1].job_template == t_a
+        assert jobs[1].organization == org_a
+        assert jobs[1].job_template.organization == org_a
+
+        assert jobs[2].job_template == t_b
+        assert jobs[2].organization == org_b
+        assert jobs[2].job_template.organization == org_b

--- a/src/backend/tests/unit/test_parser.py
+++ b/src/backend/tests/unit/test_parser.py
@@ -245,7 +245,15 @@ class TestParser:
     @pytest.mark.parametrize('expected', [
         job_template_expected_data
     ])
-    def test_update_job_template(self, cluster, cluster_sync_data, job_templates, expected):
+    def test_update_job_template(self, cluster, cluster_sync_data, job_templates, organizations, expected):
+        # Parser resolves org from job's summary_fields and includes it in
+        # the template lookup. The fixture template must have the matching
+        # org so the lookup finds it (instead of creating a new template).
+        org_a = Organization.objects.get(cluster=cluster, external_id=2)
+        tmpl_b = JobTemplate.objects.get(cluster=cluster, external_id=2)
+        tmpl_b.organization = org_a
+        tmpl_b.save(update_fields=['organization_id'])
+
         parser = DataParser(cluster_sync_data.id)
         assert JobTemplate.objects.count() == 3
         job_template = parser.job_template


### PR DESCRIPTION
Continuation of https://github.com/ansible/automation-reports/pull/249

If JobTemplate does not have organization, then derive organization from corresponding Jobs. Also add DB migration to update existing JobTemplates.

PR does not (yet) include additional DB constrain for JobTemplate.organization. Need to check if there are corner cases where code would left JobTemplate.organization for a short period of time (parse run after 2 syncs, task container restart at wrong time, etc).