### PR TITLE
fix: add inventory setup for online installer build

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -70,7 +70,7 @@ jobs:
           podman login -u "${{ vars.REGISTRY_REDHAT_IO_USERNAME }}" -p "${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}" registry.redhat.io
           podman login -u "${{ vars.REGISTRY_STAGE_REDHAT_IO_USERNAME }}" -p "${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}" registry.stage.redhat.io
           podman login -u "${{ vars.REGISTRY_QUAY_IO_USERNAME }}" -p "${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}" quay.io
-      - name: Prepare inventory
+      - name: Prepare inventory for offline installer build
         run: |
           REGISTRY_URL_AAP_AUTOMATION_DASHBOARD=$(echo "${{ env.SELECTED_AAP_DASHBOARD_IMAGE }}" | cut -d'/' -f1)
           if [[ "$REGISTRY_URL_AAP_AUTOMATION_DASHBOARD" == "quay.io" ]]; then
@@ -90,7 +90,6 @@ jobs:
           cat <<EOF >setup/inventory
           [automationdashboard]
           host.example.com ansible_connection=local
-          [automationdashboardeporter:vars]
           [all:vars]
           registry_username=${{ vars.REGISTRY_REDHAT_IO_USERNAME }}
           registry_password=${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
@@ -138,6 +137,14 @@ jobs:
           echo "  VERSION: $VERSION"
           echo "  Branch: $GITHUB_REF_NAME"
           echo "  Bundled installer: no"
+      - name: Prepare inventory for online installer build
+        run: |
+          cat <<EOF >setup/inventory
+          [automationdashboard]
+          host.example.com ansible_connection=local
+          [all:vars]
+          bundle_install=false
+          EOF
       - name: Build online installer
         run: >
           AAP_DASHBOARD_BUNDLED_INSTALLER=0


### PR DESCRIPTION
## Summary
- The `online-installer` GHA job was missing a "Prepare inventory" step, causing `build_installer.sh` to fail with "setup/inventory file not found"
- Adds a new step to create a minimal `setup/inventory` with `bundle_install=false` before the online build
- Removes the broken `[automationdashboardeporter:vars]` section header from the bundled inventory

## Test plan
- [x] Verify the `Build online installer` job passes in CI
- [x] Verify the `Build bundled installer` jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified installer inventory preparation steps for offline and connected installations.
  * Removed an unused inventory configuration section from bundled installers.
  * Added explicit inventory generation for online installers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->