### PR TITLE
AAP-83974 fix: include redirect_uri in OAuth2 authorize request

### DIFF
--- a/src/frontend/app/Components/Login.tsx
+++ b/src/frontend/app/Components/Login.tsx
@@ -24,7 +24,8 @@ export const Login: React.FunctionComponent = () => {
   const [errorMessage, seterrorMessage] = useState('false');
 
   const loginWithAAP = () => {
-    window.location.href = `${appSettings?.url}?client_id=${appSettings?.client_id}&response_type=${appSettings?.response_type}&approval_prompt=${appSettings?.approval_prompt}`;
+    const redirectUri = encodeURIComponent(window.location.origin + '/auth-callback');
+    window.location.href = `${appSettings?.url}?client_id=${appSettings?.client_id}&response_type=${appSettings?.response_type}&approval_prompt=${appSettings?.approval_prompt}&redirect_uri=${redirectUri}`;
   };
 
   const handleLogin = (code: string) => {


### PR DESCRIPTION
## Summary
- Include `redirect_uri` parameter in the OAuth2 authorization GET request to `/o/authorize/`
- Without it, the OAuth2 server uses its first registered redirect URI by default, which breaks when multiple redirect URIs are configured on the server-side OAuth2 application
- The `redirect_uri` is constructed from `window.location.origin + '/auth-callback'`, matching the value already sent in the token exchange POST

## Test plan
- [ ] Deploy with AAP OAuth2 app configured with a single redirect URI — login works as before
- [x] Deploy with AAP OAuth2 app configured with multiple redirect URIs (space-separated) — login works from each registered origin
- [x] Verify the authorize GET includes `redirect_uri` query param in browser devtools
- [x] Verify the `redirect_uri` in the authorize GET matches the one in the token POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved third-party login redirects by providing a properly encoded callback URL, helping users return to the application after authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->