### PR TITLE
ci: build and push quay.io images for PRs with 14-day expiry

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Set build date
         run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
       - name: Set image tag and metadata
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
@@ -48,7 +50,7 @@ jobs:
             {
               echo 'EXTRA_LABELS<<EOF'
               echo "quay.expires-after=14d"
-              echo "org.opencontainers.image.ref.name=${{ github.head_ref }}"
+              echo "org.opencontainers.image.ref.name=${PR_HEAD_REF}"
               echo "io.github.pull_request.number=${{ github.event.pull_request.number }}"
               echo "io.github.pull_request.url=${{ github.event.pull_request.html_url }}"
               echo 'EOF'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,11 +7,17 @@ name: Build
 # GHA secrets:
 #  - REGISTRY_REDHAT_IO_PASSWORD
 #  - REGISTRY_QUAY_IO_PASSWORD
+#
+# Note: pull_request builds from forks won't have access to secrets.
+# Use pull_request_target if fork PRs need image builds (has security implications).
 
 on:
   push:
     tags:
       - 'v*.*.*'
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 
@@ -32,23 +38,44 @@ jobs:
       - run: podman info
       - name: Set build date
         run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+      - name: Set image tag and metadata
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+            SHORT_SHA=$(echo "${COMMIT_SHA}" | cut -c1-7)
+            echo "IMAGE_TAG=git-${SHORT_SHA}" >> $GITHUB_ENV
+            echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
+            {
+              echo 'EXTRA_LABELS<<EOF'
+              echo "quay.expires-after=14d"
+              echo "org.opencontainers.image.ref.name=${{ github.head_ref }}"
+              echo "io.github.pull_request.number=${{ github.event.pull_request.number }}"
+              echo "io.github.pull_request.url=${{ github.event.pull_request.html_url }}"
+              echo 'EOF'
+            } >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+            echo "EXTRA_LABELS=" >> $GITHUB_ENV
+          fi
       - name: Buildah Action
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: automation-dashboard
-          tags: ${{ github.ref_name }}
+          tags: ${{ env.IMAGE_TAG }}
           containerfiles: |
             ./docker/Dockerfile.backend
           labels: |
             org.opencontainers.image.created=${{ env.BUILD_DATE }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ env.COMMIT_SHA }}
             org.opencontainers.image.source=${{ github.repository }}
-            org.opencontainers.image.version=${{ github.ref_name }}
-      - run: podman image inspect automation-dashboard:${{ github.ref_name }}
+            org.opencontainers.image.version=${{ env.IMAGE_TAG }}
+            ${{ env.EXTRA_LABELS }}
+      - run: podman image inspect automation-dashboard:${{ env.IMAGE_TAG }}
       - run: podman image ls | grep automation-dashboard
       - name: Test built image
-        run: podman run --rm automation-dashboard:${{ github.ref_name }} /venv/bin/python ./manage.py -h
+        run: podman run --rm automation-dashboard:${{ env.IMAGE_TAG }} /venv/bin/python ./manage.py -h
       - name: Push To quay.io
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
@@ -58,4 +85,3 @@ jobs:
           registry: quay.io/aap
           username: ${{ vars.REGISTRY_QUAY_IO_USERNAME }}
           password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}
-

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,9 +7,6 @@ name: Build
 # GHA secrets:
 #  - REGISTRY_REDHAT_IO_PASSWORD
 #  - REGISTRY_QUAY_IO_PASSWORD
-#
-# Note: pull_request builds from forks won't have access to secrets.
-# Use pull_request_target if fork PRs need image builds (has security implications).
 
 on:
   push:
@@ -23,6 +20,8 @@ on:
 
 jobs:
   build-image:
+    # Skip fork PRs — they don't have access to registry secrets
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to the Build workflow so images are built for PRs targeting `main`
- PR images are tagged as `git-<short-sha>` (7-char commit SHA) and carry the `quay.expires-after=14d` label for automatic cleanup on quay.io
- The `:main` and version-tag images remain unchanged with no expiry
- PR images include OCI labels with the source branch name, PR number, and PR URL for traceability
- Uses `github.event.pull_request.head.sha` (actual commit) instead of `github.sha` (merge commit) for the revision label on PR builds

## Test plan
- [ ] Open this PR and verify the Build workflow triggers
- [ ] Check the built image is tagged `git-<sha>` on quay.io
- [ ] Inspect image labels for `quay.expires-after=14d`, branch name, PR number/URL
- [ ] Verify a push to `main` still produces `:main` tag without expiry label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated container image builds for pull requests targeting the main branch, while skipping builds for fork pull requests that lack required secret access.
  * Refined image tagging and metadata: pull request images now use a PR-based tag and include pull-request details in OCI labels; non-pull-request builds retain prior tagging behavior.
  * Updated image inspection/validation steps to consistently reference the newly generated image tag.
  * Kept container publishing behavior unchanged for releases and main branch builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->